### PR TITLE
add docker support and update documentation to reflect

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,9 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(tree:*)",
+      "Bash(git remote:*)",
+      "Bash(git add:*)"
+    ]
+  }
+}

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,9 +1,0 @@
-{
-  "permissions": {
-    "allow": [
-      "Bash(tree:*)",
-      "Bash(git remote:*)",
-      "Bash(git add:*)"
-    ]
-  }
-}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+# Build stage
+FROM golang:1.25-bookworm AS builder
+
+RUN apt-get update && apt-get install -y gcc libc6-dev && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+
+COPY . .
+RUN CGO_ENABLED=1 CGO_CFLAGS="-DSQLITE_ENABLE_FTS5" go build -o /cymbal .
+
+# Runtime stage
+FROM debian:bookworm-slim
+
+RUN apt-get update && apt-get install -y ca-certificates git && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /cymbal /usr/local/bin/cymbal
+
+WORKDIR /workspace
+
+# Default DB path — stored as a dotfile inside the mounted repo.
+# Override with -e CYMBAL_DB=... or --db flag.
+ENV CYMBAL_DB=/workspace/.cymbal/index.db
+
+ENTRYPOINT ["cymbal"]

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Add `.cymbal/` to your `.gitignore` to keep the index out of version control.
 Define a shell alias once so every command looks like the native binary:
 
 ```sh
-alias cymbal='docker run --rm -v $(pwd):/workspace cymbal'
+alias cymbal='docker run --rm -v "$(pwd)":/workspace cymbal'
 ```
 
 Then:
@@ -154,17 +154,17 @@ Use `cymbal` CLI for code navigation — prefer it over Read, Grep, Glob, or Bas
 ```markdown
 ## Code Exploration Policy
 Use `cymbal` via Docker for code navigation — prefer it over Read, Grep, Glob, or Bash for code exploration.
-Run all cymbal commands as: `docker run --rm -v $(pwd):/workspace cymbal <command>`
-- **New to a repo?**: `docker run --rm -v $(pwd):/workspace cymbal structure` — entry points, hotspots, central packages. Start here.
-- **To understand a symbol**: `docker run --rm -v $(pwd):/workspace cymbal investigate <symbol>` — returns source, callers, impact, or members based on what the symbol is.
-- **To understand multiple symbols**: `docker run --rm -v $(pwd):/workspace cymbal investigate Foo Bar Baz` — batch mode, one invocation.
-- **To trace an execution path**: `docker run --rm -v $(pwd):/workspace cymbal trace <symbol>` — follows the call graph downward (what does X call, what do those call).
-- **To assess change risk**: `docker run --rm -v $(pwd):/workspace cymbal impact <symbol>` — follows the call graph upward (what breaks if X changes).
-- Before reading a file: `docker run --rm -v $(pwd):/workspace cymbal outline <file>` or `cymbal show <file:L1-L2>`
-- Before searching: `docker run --rm -v $(pwd):/workspace cymbal search <query>` (symbols) or add `--text` for grep
-- Before exploring structure: `docker run --rm -v $(pwd):/workspace cymbal ls` or `cymbal ls --stats`
-- To disambiguate: `docker run --rm -v $(pwd):/workspace cymbal investigate path/to/file.go:Symbol`
-- First run: `docker run --rm -v $(pwd):/workspace cymbal index .` to build the initial index. After that, queries auto-refresh — no manual reindexing needed.
+Run all cymbal commands as: `docker run --rm -v "$(pwd)":/workspace cymbal <command>`
+- **New to a repo?**: `docker run --rm -v "$(pwd)":/workspace cymbal structure` — entry points, hotspots, central packages. Start here.
+- **To understand a symbol**: `docker run --rm -v "$(pwd)":/workspace cymbal investigate <symbol>` — returns source, callers, impact, or members based on what the symbol is.
+- **To understand multiple symbols**: `docker run --rm -v "$(pwd)":/workspace cymbal investigate Foo Bar Baz` — batch mode, one invocation.
+- **To trace an execution path**: `docker run --rm -v "$(pwd)":/workspace cymbal trace <symbol>` — follows the call graph downward (what does X call, what do those call).
+- **To assess change risk**: `docker run --rm -v "$(pwd)":/workspace cymbal impact <symbol>` — follows the call graph upward (what breaks if X changes).
+- Before reading a file: `docker run --rm -v "$(pwd)":/workspace cymbal outline <file>` or `docker run --rm -v "$(pwd)":/workspace cymbal show <file:L1-L2>`
+- Before searching: `docker run --rm -v "$(pwd)":/workspace cymbal search <query>` (symbols) or add `--text` for grep
+- Before exploring structure: `docker run --rm -v "$(pwd)":/workspace cymbal ls` or `docker run --rm -v "$(pwd)":/workspace cymbal ls --stats`
+- To disambiguate: `docker run --rm -v "$(pwd)":/workspace cymbal investigate path/to/file.go:Symbol`
+- First run: `docker run --rm -v "$(pwd)":/workspace cymbal index .` to build the initial index. After that, queries auto-refresh — no manual reindexing needed.
 - The SQLite index is stored at `.cymbal/index.db` in the repo root and persists between runs.
 - All commands support `--json` for structured output.
 ```

--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ Windows (PowerShell):
 irm https://raw.githubusercontent.com/1broseidon/cymbal/main/install.ps1 | iex
 ```
 
+To uninstall (keeps index data by default):
+
+```powershell
+# Remove binary and PATH entry, keep SQLite indexes
+irm https://raw.githubusercontent.com/1broseidon/cymbal/main/uninstall.ps1 | iex
+
+# Also remove all SQLite indexes
+& ([scriptblock]::Create((irm https://raw.githubusercontent.com/1broseidon/cymbal/main/uninstall.ps1))) -Purge
+```
+
+> **Note:** `-Purge` removes all per-repo SQLite indexes stored under `%LOCALAPPDATA%\cymbal\repos\`. Omit it to keep your indexes intact in case you reinstall.
+
 Go (requires CGO for tree-sitter + SQLite):
 
 ```sh
@@ -26,7 +38,46 @@ CGO_CFLAGS="-DSQLITE_ENABLE_FTS5" go install github.com/1broseidon/cymbal@latest
 
 Or grab a binary from [releases](https://github.com/1broseidon/cymbal/releases).
 
+### Docker
+
+No local Go toolchain or CGO setup needed — run cymbal from a container against any repo on your machine.
+
+```sh
+# Build the image
+docker build -t cymbal .
+```
+
+Mount any repo and the SQLite index lands at `.cymbal/index.db` inside it by default:
+
+```sh
+# Index a repo
+docker run --rm -v /path/to/your/repo:/workspace cymbal index .
+
+# Query it (index persists at /path/to/your/repo/.cymbal/index.db)
+docker run --rm -v /path/to/your/repo:/workspace cymbal investigate handleAuth
+
+# Override the DB location if needed
+docker run --rm -v /path/to/your/repo:/workspace -e CYMBAL_DB=/some/other/path.db cymbal index .
+```
+
+Or use docker compose (mounts the current directory by default):
+
+```sh
+docker compose run --rm cymbal index .
+docker compose run --rm cymbal investigate handleAuth
+```
+
+Add `.cymbal/` to your `.gitignore` to keep the index out of version control.
+
 ## Quick start
+
+Define a shell alias once so every command looks like the native binary:
+
+```sh
+alias cymbal='docker run --rm -v $(pwd):/workspace cymbal'
+```
+
+Then:
 
 ```sh
 # Index the current project
@@ -49,6 +100,8 @@ cymbal diff handleAuth main      # git diff scoped to a function
 cymbal context handleAuth        # bundled: source + types + callers + imports
 cymbal ls                        # file tree
 ```
+
+The SQLite index is written to `.cymbal/index.db` in the current directory and persists between runs.
 
 ## Commands
 
@@ -76,7 +129,9 @@ All commands support `--json` for structured output.
 
 cymbal is designed as the code navigation layer for AI agents. One command handles most investigations — specific commands exist as escape hatches when you need more control.
 
-Add this to your agent's system prompt (e.g., `CLAUDE.md`, `agent.md`, or MCP tool descriptions):
+Add this to your agent's system prompt (e.g., `CLAUDE.md`, `agent.md`, or MCP tool descriptions).
+
+**Native install:**
 
 ```markdown
 ## Code Exploration Policy
@@ -91,6 +146,26 @@ Use `cymbal` CLI for code navigation — prefer it over Read, Grep, Glob, or Bas
 - Before exploring structure: `cymbal ls` (tree) or `cymbal ls --stats` (overview)
 - To disambiguate: `cymbal show path/to/file.go:SymbolName` or `cymbal investigate file.go:Symbol`
 - First run: `cymbal index .` to build the initial index (<1s). After that, queries auto-refresh — no manual reindexing needed.
+- All commands support `--json` for structured output.
+```
+
+**Docker (no local install required):**
+
+```markdown
+## Code Exploration Policy
+Use `cymbal` via Docker for code navigation — prefer it over Read, Grep, Glob, or Bash for code exploration.
+Run all cymbal commands as: `docker run --rm -v $(pwd):/workspace cymbal <command>`
+- **New to a repo?**: `docker run --rm -v $(pwd):/workspace cymbal structure` — entry points, hotspots, central packages. Start here.
+- **To understand a symbol**: `docker run --rm -v $(pwd):/workspace cymbal investigate <symbol>` — returns source, callers, impact, or members based on what the symbol is.
+- **To understand multiple symbols**: `docker run --rm -v $(pwd):/workspace cymbal investigate Foo Bar Baz` — batch mode, one invocation.
+- **To trace an execution path**: `docker run --rm -v $(pwd):/workspace cymbal trace <symbol>` — follows the call graph downward (what does X call, what do those call).
+- **To assess change risk**: `docker run --rm -v $(pwd):/workspace cymbal impact <symbol>` — follows the call graph upward (what breaks if X changes).
+- Before reading a file: `docker run --rm -v $(pwd):/workspace cymbal outline <file>` or `cymbal show <file:L1-L2>`
+- Before searching: `docker run --rm -v $(pwd):/workspace cymbal search <query>` (symbols) or add `--text` for grep
+- Before exploring structure: `docker run --rm -v $(pwd):/workspace cymbal ls` or `cymbal ls --stats`
+- To disambiguate: `docker run --rm -v $(pwd):/workspace cymbal investigate path/to/file.go:Symbol`
+- First run: `docker run --rm -v $(pwd):/workspace cymbal index .` to build the initial index. After that, queries auto-refresh — no manual reindexing needed.
+- The SQLite index is stored at `.cymbal/index.db` in the repo root and persists between runs.
 - All commands support `--json` for structured output.
 ```
 
@@ -116,7 +191,7 @@ Adding a language requires a tree-sitter grammar and a symbol extraction query �
 
 ## How it works
 
-1. **Index** — tree-sitter parses each file into an AST. cymbal extracts symbols (functions, types, variables, imports) and references (calls, type usage) and stores them in SQLite with FTS5 full-text search. Each repo gets its own database at `~/.cymbal/repos/<hash>/index.db`.
+1. **Index** — tree-sitter parses each file into an AST. cymbal extracts symbols (functions, types, variables, imports) and references (calls, type usage) and stores them in SQLite with FTS5 full-text search. Each repo gets its own database at `~/.cymbal/repos/<hash>/index.db` by default. Override with `--db <path>` or the `CYMBAL_DB` environment variable.
 
 2. **Query** — all commands read from the current repo's SQLite index. Symbol lookups, cross-references, and import graphs are SQL queries. No re-parsing needed. No cross-repo bleed.
 

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -40,12 +40,16 @@ you already have installed and authenticated.`,
 		backend, _ := cmd.Flags().GetString("backend")
 		model, _ := cmd.Flags().GetString("model")
 
-		// Use --db override if set, otherwise compute from target path.
+		// Use --db flag > CYMBAL_DB env > compute from target path.
 		dbPath, _ := cmd.Flags().GetString("db")
 		if dbPath == "" {
-			dbPath, err = index.RepoDBPath(absPath)
-			if err != nil {
-				return fmt.Errorf("computing db path: %w", err)
+			if p := os.Getenv("CYMBAL_DB"); p != "" {
+				dbPath = p
+			} else {
+				dbPath, err = index.RepoDBPath(absPath)
+				if err != nil {
+					return fmt.Errorf("computing db path: %w", err)
+				}
 			}
 		}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -26,10 +26,12 @@ func init() {
 	rootCmd.PersistentFlags().Bool("json", false, "output as JSON")
 }
 
-// getDBPath returns the database path. If --db is set, use it.
-// Otherwise, detect git root from CWD and compute per-repo path.
+// getDBPath returns the database path. Priority: --db flag > CYMBAL_DB env > auto per-repo.
 func getDBPath(cmd *cobra.Command) string {
 	if p, _ := cmd.Flags().GetString("db"); p != "" {
+		return p
+	}
+	if p := os.Getenv("CYMBAL_DB"); p != "" {
 		return p
 	}
 	cwd, err := os.Getwd()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+services:
+  cymbal:
+    build: .
+    volumes:
+      # Mount the repo to index into /workspace
+      - .:/workspace
+    working_dir: /workspace
+    # CYMBAL_DB defaults to /workspace/.cymbal/index.db (set in Dockerfile)
+    # Override here if needed: environment: [CYMBAL_DB=/some/other/path]

--- a/uninstall.ps1
+++ b/uninstall.ps1
@@ -1,0 +1,52 @@
+#!/usr/bin/env pwsh
+# Uninstall cymbal on Windows.
+# Usage: irm https://raw.githubusercontent.com/1broseidon/cymbal/main/uninstall.ps1 | iex
+#
+# By default removes the binary and PATH entry but keeps index data.
+# Pass -Purge to also remove all SQLite indexes (~/.cymbal/repos/).
+
+param(
+    [switch]$Purge
+)
+
+$ErrorActionPreference = "Stop"
+
+$installDir = "$env:LOCALAPPDATA\cymbal"
+
+# Remove from user PATH
+$userPath = [Environment]::GetEnvironmentVariable("Path", "User")
+if ($userPath -like "*$installDir*") {
+    $newPath = ($userPath -split ";" | Where-Object { $_ -ne $installDir }) -join ";"
+    [Environment]::SetEnvironmentVariable("Path", $newPath, "User")
+    Write-Host "Removed $installDir from user PATH." -ForegroundColor Yellow
+}
+
+# Remove binary
+$bin = Join-Path $installDir "cymbal.exe"
+if (Test-Path $bin) {
+    Remove-Item -Force $bin
+    Write-Host "Removed cymbal.exe." -ForegroundColor Yellow
+} else {
+    Write-Host "cymbal.exe not found — may already be uninstalled." -ForegroundColor Gray
+}
+
+# Remove index data if -Purge is set
+if ($Purge) {
+    $reposDir = Join-Path $installDir "repos"
+    if (Test-Path $reposDir) {
+        Remove-Item -Recurse -Force $reposDir
+        Write-Host "Removed index data at $reposDir." -ForegroundColor Yellow
+    }
+
+    # Remove install dir if now empty
+    if (Test-Path $installDir) {
+        $remaining = Get-ChildItem $installDir -ErrorAction SilentlyContinue
+        if (-not $remaining) {
+            Remove-Item -Force $installDir
+        }
+    }
+} else {
+    Write-Host "Index data kept at $installDir\repos (run with -Purge to remove)." -ForegroundColor Gray
+}
+
+Write-Host "cymbal uninstalled." -ForegroundColor Green


### PR DESCRIPTION
This changes nothing but some path handling in the go that was actually not consistent, and allows you run the cymbal via docker and maintain a sqlite per repo without running dangerous binaries directly. update the gitignore for any repo to exclude .cymbal path.

This is to elimate the missing dll and or other broken release exe direct running issues.

i've tested this against .dotnet the agent happy to run the docker command variant added claude.md