### PR TITLE
feat: proper Kotlin symbol extraction

### DIFF
--- a/cmd/show.go
+++ b/cmd/show.go
@@ -171,7 +171,7 @@ const maxTypeShowLines = 60
 
 func isTypeKind(kind string) bool {
 	switch kind {
-	case "class", "struct", "type", "interface", "trait", "enum":
+	case "class", "struct", "type", "interface", "trait", "enum", "object":
 		return true
 	}
 	return false

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -926,7 +926,7 @@ func Investigate(dbPath, symbolName string, opts ...InvestigateOpts) (*Investiga
 		res.Refs, _ = store.FindReferences(sym.Name, 20)
 		res.Impact, _ = store.FindImpact(sym.Name, 2, 20)
 
-	case "class", "struct", "type", "interface", "trait", "enum":
+	case "class", "struct", "type", "interface", "trait", "enum", "object":
 		res.Kind = "type"
 		res.Members, _ = store.ChildSymbols(sym.Name, 50)
 		// For types, show who references the type name.
@@ -955,7 +955,7 @@ func InvestigateResolved(dbPath string, sym SymbolResult) (*InvestigateResult, e
 	srcEnd := sym.EndLine
 	truncated := false
 	switch sym.Kind {
-	case "class", "struct", "type", "interface", "trait", "enum":
+	case "class", "struct", "type", "interface", "trait", "enum", "object":
 		if srcEnd-sym.StartLine+1 > maxTypeLines {
 			srcEnd = sym.StartLine + maxTypeLines - 1
 			truncated = true
@@ -977,7 +977,7 @@ func InvestigateResolved(dbPath string, sym SymbolResult) (*InvestigateResult, e
 		res.Kind = "function"
 		res.Refs, _ = store.FindReferences(sym.Name, 20)
 		res.Impact, _ = store.FindImpact(sym.Name, 2, 20)
-	case "class", "struct", "type", "interface", "trait", "enum":
+	case "class", "struct", "type", "interface", "trait", "enum", "object":
 		res.Kind = "type"
 		res.Members, _ = store.ChildSymbols(sym.Name, 50)
 		res.Refs, _ = store.FindReferences(sym.Name, 20)

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -180,8 +180,13 @@ func (e *symbolExtractor) extractImport(node *sitter.Node) (symbols.Import, bool
 			content := node.Content(e.src)
 			return symbols.Import{RawPath: content, Language: e.lang}, true
 		}
-	case "java", "kotlin", "scala":
+	case "java", "scala":
 		if nodeType == "import_declaration" {
+			content := node.Content(e.src)
+			return symbols.Import{RawPath: content, Language: e.lang}, true
+		}
+	case "kotlin":
+		if nodeType == "import_header" {
 			content := node.Content(e.src)
 			return symbols.Import{RawPath: content, Language: e.lang}, true
 		}
@@ -272,7 +277,7 @@ func (e *symbolExtractor) extractRef(node *sitter.Node) (symbols.Ref, bool) {
 				}
 			}
 		}
-	case "java", "kotlin", "scala":
+	case "java", "scala":
 		if nodeType == "method_invocation" {
 			nameNode := node.ChildByFieldName("name")
 			if nameNode != nil {
@@ -281,6 +286,21 @@ func (e *symbolExtractor) extractRef(node *sitter.Node) (symbols.Ref, bool) {
 					Line:     int(node.StartPoint().Row) + 1,
 					Language: e.lang,
 				}, true
+			}
+		}
+	case "kotlin":
+		if nodeType == "call_expression" {
+			// First child is the callee (simple_identifier or navigation_expression).
+			if node.ChildCount() > 0 {
+				callee := node.Child(0)
+				name := extractCallName(callee, e.src)
+				if name != "" {
+					return symbols.Ref{
+						Name:     name,
+						Line:     int(node.StartPoint().Row) + 1,
+						Language: e.lang,
+					}, true
+				}
 			}
 		}
 	case "ruby":
@@ -352,8 +372,10 @@ func (e *symbolExtractor) classifyNode(nodeType string, node *sitter.Node) (stri
 		return e.classifyJS(nodeType, node)
 	case "rust":
 		return e.classifyRust(nodeType, node)
-	case "java", "kotlin", "scala":
+	case "java", "scala":
 		return e.classifyJavaLike(nodeType, node)
+	case "kotlin":
+		return e.classifyKotlin(nodeType, node)
 	case "ruby":
 		return e.classifyRuby(nodeType, node)
 	case "c", "cpp":
@@ -550,6 +572,90 @@ func (e *symbolExtractor) classifyJavaLike(nodeType string, node *sitter.Node) (
 	return "", nil
 }
 
+// findChildByType returns the first direct child with the given type.
+func findChildByType(node *sitter.Node, typeName string) *sitter.Node {
+	for i := range int(node.ChildCount()) {
+		c := node.Child(i)
+		if c.Type() == typeName {
+			return c
+		}
+	}
+	return nil
+}
+
+// hasChildOfType reports whether node has any direct child with the given type.
+func hasChildOfType(node *sitter.Node, typeName string) bool {
+	return findChildByType(node, typeName) != nil
+}
+
+// kotlinInsideClassBody returns true if node sits inside a class_body /
+// enum_class_body (i.e. its declaration is a member of a class/object).
+func kotlinInsideClassBody(node *sitter.Node) bool {
+	p := node.Parent()
+	if p == nil {
+		return false
+	}
+	t := p.Type()
+	return t == "class_body" || t == "enum_class_body"
+}
+
+func (e *symbolExtractor) classifyKotlin(nodeType string, node *sitter.Node) (string, *sitter.Node) {
+	switch nodeType {
+	case "class_declaration":
+		// Distinguish class / interface / enum by leading keyword child.
+		kind := "class"
+		if hasChildOfType(node, "interface") {
+			kind = "interface"
+		} else if hasChildOfType(node, "enum") {
+			kind = "enum"
+		}
+		return kind, findChildByType(node, "type_identifier")
+	case "object_declaration":
+		return "object", findChildByType(node, "type_identifier")
+	case "companion_object":
+		// Named companion (`companion object Foo`) has a type_identifier; emit it.
+		// Anonymous `companion object` is skipped — members still belong to the
+		// enclosing class via the walker's parent tracking.
+		if nameNode := findChildByType(node, "type_identifier"); nameNode != nil {
+			return "object", nameNode
+		}
+		return "", nil
+	case "function_declaration":
+		kind := "function"
+		if kotlinInsideClassBody(node) {
+			kind = "method"
+		}
+		return kind, findChildByType(node, "simple_identifier")
+	case "property_declaration":
+		varDecl := findChildByType(node, "variable_declaration")
+		if varDecl == nil {
+			return "", nil
+		}
+		nameNode := findChildByType(varDecl, "simple_identifier")
+		// Determine kind: const val → constant; inside class_body → field; else variable.
+		kind := "variable"
+		if kotlinInsideClassBody(node) {
+			kind = "field"
+		}
+		// Detect `const` modifier.
+		if mods := findChildByType(node, "modifiers"); mods != nil {
+			for i := range int(mods.ChildCount()) {
+				c := mods.Child(i)
+				if c.Type() == "property_modifier" && c.Content(e.src) == "const" {
+					kind = "constant"
+					break
+				}
+			}
+		}
+		return kind, nameNode
+	case "type_alias":
+		return "type", findChildByType(node, "type_identifier")
+	case "enum_entry":
+		return "enum_member", findChildByType(node, "simple_identifier")
+	}
+	return "", nil
+}
+
 func (e *symbolExtractor) classifyRuby(nodeType string, node *sitter.Node) (string, *sitter.Node) {
 	switch nodeType {
 	case "method":
@@ -600,7 +706,11 @@ func (e *symbolExtractor) extractSignature(node *sitter.Node, kind string) strin
 		if params != nil {
 			return params.Content(e.src)
 		}
-	case "struct", "class", "interface", "trait":
+		// Kotlin grammar has no "parameters" field — look up by type.
+		if fvp := findChildByType(node, "function_value_parameters"); fvp != nil {
+			return fvp.Content(e.src)
+		}
+	case "struct", "class", "interface", "trait", "object", "enum":
 		content := node.Content(e.src)
 		for i, ch := range content {
 			if ch == '\n' || ch == '{' {

--- a/internal/parser/parser_feature_test.go
+++ b/internal/parser/parser_feature_test.go
@@ -703,6 +703,144 @@ impl Circle {
 	}
 }
 
+// --- Kotlin Language Feature Tests ---
+
+func TestFeatureKotlinSymbols(t *testing.T) {
+	src := []byte(`package com.example.foo
+
+import com.fasterxml.jackson.annotation.JsonProperty
+import kotlinx.coroutines.flow.Flow
+
+@JvmInline
+value class ItemId(val value: String)
+
+enum class ItemType { NORMAL, CONTAINER }
+
+data class Item(
+  val id: ItemId,
+  val type: ItemType,
+)
+
+interface GameEngine {
+  fun start()
+  fun stop()
+}
+
+object Singleton {
+  const val VERSION = "1.0"
+  fun boot() {}
+}
+
+typealias UserId = String
+
+class GameSession(val id: String) {
+  val createdAt: Long = 0L
+  fun tick() {
+    println("tick")
+    doThing()
+  }
+
+  companion object {
+    fun create(): GameSession = GameSession("")
+  }
+}
+
+fun topLevel(a: Int): Int = a + 1
+
+val GLOBAL = 42
+`)
+	result, err := ParseSource(src, "test.kt", "kotlin", languages["kotlin"])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Value class / data class / regular class — all kind "class".
+	if findSymbolKind(result.Symbols, "ItemId", "class") == nil {
+		t.Error("expected ItemId value class")
+	}
+	if findSymbolKind(result.Symbols, "Item", "class") == nil {
+		t.Error("expected Item data class")
+	}
+	if findSymbolKind(result.Symbols, "GameSession", "class") == nil {
+		t.Error("expected GameSession class")
+	}
+
+	// Enum class.
+	if findSymbolKind(result.Symbols, "ItemType", "enum") == nil {
+		t.Error("expected ItemType enum")
+	}
+
+	// Interface.
+	if findSymbolKind(result.Symbols, "GameEngine", "interface") == nil {
+		t.Error("expected GameEngine interface")
+	}
+
+	// Object.
+	if findSymbolKind(result.Symbols, "Singleton", "object") == nil {
+		t.Error("expected Singleton object")
+	}
+
+	// typealias.
+	if findSymbolKind(result.Symbols, "UserId", "type") == nil {
+		t.Error("expected UserId type alias")
+	}
+
+	// Top-level function.
+	if findSymbolKind(result.Symbols, "topLevel", "function") == nil {
+		t.Error("expected topLevel function")
+	}
+
+	// Top-level property.
+	if findSymbolKind(result.Symbols, "GLOBAL", "variable") == nil {
+		t.Error("expected GLOBAL variable")
+	}
+
+	// const val inside object → constant.
+	if findSymbolKind(result.Symbols, "VERSION", "constant") == nil {
+		t.Error("expected VERSION constant")
+	}
+
+	// Method inside class.
+	tick := findSymbolKind(result.Symbols, "tick", "method")
+	if tick == nil {
+		t.Fatal("expected tick method")
+	}
+	if tick.Parent != "GameSession" {
+		t.Errorf("expected tick parent GameSession, got %q", tick.Parent)
+	}
+
+	// Field inside class.
+	if findSymbolKind(result.Symbols, "createdAt", "field") == nil {
+		t.Error("expected createdAt field")
+	}
+
+	// Enum member.
+	if findSymbolKind(result.Symbols, "NORMAL", "enum_member") == nil {
+		t.Error("expected NORMAL enum_member")
+	}
+
+	// Imports.
+	if findImport(result.Imports, "com.fasterxml.jackson.annotation.JsonProperty") == nil {
+		t.Error("expected JsonProperty import")
+	}
+	if findImport(result.Imports, "kotlinx.coroutines.flow.Flow") == nil {
+		t.Error("expected Flow import")
+	}
+
+	// Refs from call_expression.
+	if findRef(result.Refs, "println") == nil {
+		t.Error("expected println ref")
+	}
+	if findRef(result.Refs, "doThing") == nil {
+		t.Error("expected doThing ref")
+	}
+
+	// Signature should be captured for functions.
+	if topLevel := findSymbol(result.Symbols, "topLevel"); topLevel == nil || topLevel.Signature == "" {
+		t.Error("expected non-empty signature for topLevel function")
+	}
+}
+
 // --- Multi-language table-driven test ---
 
 func TestFeatureParseMultiLanguage(t *testing.T) {


### PR DESCRIPTION
## Summary

Kotlin files were being indexed using the Java classifier, but tree-sitter-kotlin has a different grammar — no `name` field on declarations, and different node types (`class_declaration` with `type_identifier` child, `object_declaration`, `property_declaration`, `type_alias`, `enum_entry`, `import_header`, etc.). The result: almost no Kotlin symbols were extracted.

This PR adds a dedicated Kotlin classifier so Kotlin codebases become searchable.

## Changes

- **`internal/parser/parser.go`**
  - New `classifyKotlin` handling `class_declaration` (with kind disambiguation for `interface`/`enum`), `object_declaration`, `function_declaration` (method vs function based on class_body parent), `property_declaration` (constant/field/variable based on `const` modifier and parent), `type_alias`, `enum_entry`, `companion_object`.
  - `extractImport` handles Kotlin's `import_header` node.
  - `extractRef` handles Kotlin's `call_expression` (callee is the first child, either `simple_identifier` or `navigation_expression`).
  - `extractSignature` falls back to `function_value_parameters` by type (Kotlin has no `parameters` field) and includes `object`/`enum` in the first-line slice.
  - Small helpers `findChildByType` / `hasChildOfType`.

- **New symbol kinds**
  - `"object"` — Kotlin singletons. Added to the type-like whitelists in `internal/index/index.go` (3 switches) and `cmd/show.go` so `investigate`/`show` treat them like classes (list members, truncate).
  - `"enum_member"` — emitted for Kotlin `enum_entry`. No existing language emits individual enum members today; kept as a new kind rather than overloading `"constant"`.

## Tests

New `TestFeatureKotlinSymbols` in `internal/parser/parser_feature_test.go` covering value/data/regular class, enum class, interface, object, companion object, typealias, top-level fn/val, `const val`, method, field, enum member, imports, refs, and signature extraction.

## Verified on

Indexed a ~440-file Kotlin project (server + Compose UI + shared modules). Before: Kotlin symbols essentially missing. After: 4168 symbols indexed; `cymbal search ItemId` / `cymbal search GameEngine` / `cymbal investigate WorldYaml` (object) all work.