### PR TITLE
feat(parser): add Dart language support

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ An agent tracing an auth flow typically makes 15-20 sequential tool calls: show 
 
 cymbal uses tree-sitter grammars. Currently supported:
 
-Go, Python, JavaScript, TypeScript, TSX, Rust, C, C++, C#, Java, Ruby, Swift, Kotlin, Scala, PHP, Lua, Bash, YAML, Elixir, HCL/Terraform, Protobuf
+Go, Python, JavaScript, TypeScript, TSX, Rust, C, C++, C#, Java, Ruby, Swift, Kotlin, Scala, PHP, Lua, Bash, YAML, Elixir, HCL/Terraform, Protobuf, Dart
 
 Adding a language requires a tree-sitter grammar and a symbol extraction query — see `internal/parser/` for examples.
 

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -171,7 +171,7 @@ const maxTypeShowLines = 60
 
 func isTypeKind(kind string) bool {
 	switch kind {
-	case "class", "struct", "type", "interface", "trait", "enum", "object":
+	case "class", "struct", "type", "interface", "trait", "enum", "object", "mixin", "extension":
 		return true
 	}
 	return false

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.25.8
 
 require (
 	github.com/1broseidon/oneagent v0.12.0
+	github.com/UserNobody14/tree-sitter-dart v0.0.0-20240901045915-8197a3123420
 	github.com/lynxbat/go-tree-sitter-apex v0.0.0-20260405201437-d6c57d53f85c
 	github.com/mattn/go-sqlite3 v1.14.37
 	github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
 github.com/1broseidon/oneagent v0.12.0 h1:FqEaqScUyrvJEerjpgcqR34JcN1GF6yZ6ymiT26mxDs=
 github.com/1broseidon/oneagent v0.12.0/go.mod h1:5LemxCafzlumN4bum6Q57iQk/55I4bc4kgc5bcsJph8=
+github.com/UserNobody14/tree-sitter-dart v0.0.0-20240901045915-8197a3123420 h1:RdOPBceFlbOPoPyAyd+kNitLcRpnuHMYzzjguNkPNzc=
+github.com/UserNobody14/tree-sitter-dart v0.0.0-20240901045915-8197a3123420/go.mod h1:6zSIbyfHyxL/+XWRHElGLw+EUPYbDOyhDqIiAX6svrE=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/index/index.go
+++ b/internal/index/index.go
@@ -926,7 +926,7 @@ func Investigate(dbPath, symbolName string, opts ...InvestigateOpts) (*Investiga
 		res.Refs, _ = store.FindReferences(sym.Name, 20)
 		res.Impact, _ = store.FindImpact(sym.Name, 2, 20)
 
-	case "class", "struct", "type", "interface", "trait", "enum", "object":
+	case "class", "struct", "type", "interface", "trait", "enum", "object", "mixin", "extension":
 		res.Kind = "type"
 		res.Members, _ = store.ChildSymbols(sym.Name, 50)
 		// For types, show who references the type name.
@@ -955,7 +955,7 @@ func InvestigateResolved(dbPath string, sym SymbolResult) (*InvestigateResult, e
 	srcEnd := sym.EndLine
 	truncated := false
 	switch sym.Kind {
-	case "class", "struct", "type", "interface", "trait", "enum", "object":
+	case "class", "struct", "type", "interface", "trait", "enum", "object", "mixin", "extension":
 		if srcEnd-sym.StartLine+1 > maxTypeLines {
 			srcEnd = sym.StartLine + maxTypeLines - 1
 			truncated = true
@@ -977,7 +977,7 @@ func InvestigateResolved(dbPath string, sym SymbolResult) (*InvestigateResult, e
 		res.Kind = "function"
 		res.Refs, _ = store.FindReferences(sym.Name, 20)
 		res.Impact, _ = store.FindImpact(sym.Name, 2, 20)
-	case "class", "struct", "type", "interface", "trait", "enum", "object":
+	case "class", "struct", "type", "interface", "trait", "enum", "object", "mixin", "extension":
 		res.Kind = "type"
 		res.Members, _ = store.ChildSymbols(sym.Name, 50)
 		res.Refs, _ = store.FindReferences(sym.Name, 20)

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 
+	dart "github.com/UserNobody14/tree-sitter-dart/bindings/go"
 	sitter "github.com/smacker/go-tree-sitter"
 	apex "github.com/lynxbat/go-tree-sitter-apex"
 	"github.com/smacker/go-tree-sitter/bash"
@@ -44,6 +45,7 @@ var languages = map[string]*sitter.Language{
 	"c":          c.GetLanguage(),
 	"cpp":        cpp.GetLanguage(),
 	"csharp":     csharp.GetLanguage(),
+	"dart":       sitter.NewLanguage(dart.Language()),
 	"swift":      swift.GetLanguage(),
 	"kotlin":     kotlin.GetLanguage(),
 	"lua":        lua.GetLanguage(),
@@ -182,6 +184,8 @@ func (e *symbolExtractor) extractImport(node *sitter.Node) (symbols.Import, bool
 		return e.extractImportElixir(nodeType, node)
 	case "protobuf":
 		return e.extractImportProtobuf(nodeType, node)
+	case "dart":
+		return e.extractImportDart(nodeType, node)
 	}
 	return symbols.Import{}, false
 }
@@ -310,6 +314,8 @@ func (e *symbolExtractor) extractRef(node *sitter.Node) (symbols.Ref, bool) {
 		return e.extractRefRuby(nodeType, node)
 	case "elixir":
 		return e.extractRefElixir(nodeType, node)
+	case "dart":
+		return e.extractRefDart(nodeType, node)
 	}
 	return symbols.Ref{}, false
 }
@@ -484,6 +490,8 @@ func (e *symbolExtractor) classifyNode(nodeType string, node *sitter.Node) (stri
 		return e.classifyHCL(nodeType, node)
 	case "protobuf":
 		return e.classifyProtobuf(nodeType, node)
+	case "dart":
+		return e.classifyDart(nodeType, node)
 	default:
 		return e.classifyGeneric(nodeType, node)
 	}
@@ -682,6 +690,22 @@ func findChildByType(node *sitter.Node, typeName string) *sitter.Node {
 		c := node.Child(i)
 		if c.Type() == typeName {
 			return c
+		}
+	}
+	return nil
+}
+
+// findDescendantByType returns the first descendant (BFS) with the given type.
+func findDescendantByType(node *sitter.Node, typeName string) *sitter.Node {
+	for i := range int(node.ChildCount()) {
+		c := node.Child(i)
+		if c.Type() == typeName {
+			return c
+		}
+	}
+	for i := range int(node.ChildCount()) {
+		if found := findDescendantByType(node.Child(i), typeName); found != nil {
+			return found
 		}
 	}
 	return nil
@@ -937,6 +961,136 @@ func protoNameNode(node *sitter.Node, childType string) *sitter.Node {
 	return nil
 }
 
+// dartInsideClassBody reports whether node sits inside a class_body,
+// enum_body, extension_body, or mixin body — i.e. its declaration is a member.
+func dartInsideClassBody(node *sitter.Node) bool {
+	p := node.Parent()
+	for p != nil {
+		t := p.Type()
+		if t == "class_body" || t == "enum_body" || t == "extension_body" {
+			return true
+		}
+		if t == "program" {
+			return false
+		}
+		p = p.Parent()
+	}
+	return false
+}
+
+func (e *symbolExtractor) classifyDart(nodeType string, node *sitter.Node) (string, *sitter.Node) {
+	switch nodeType {
+	case "class_definition":
+		return "class", node.ChildByFieldName("name")
+	case "enum_declaration":
+		return "enum", node.ChildByFieldName("name")
+	case "mixin_declaration":
+		return "mixin", findChildByType(node, "identifier")
+	case "extension_declaration":
+		return "extension", node.ChildByFieldName("name")
+	case "type_alias":
+		return "type", findChildByType(node, "type_identifier")
+	case "function_signature":
+		kind := "function"
+		if dartInsideClassBody(node) {
+			kind = "method"
+		}
+		return kind, node.ChildByFieldName("name")
+	case "getter_signature":
+		return "getter", node.ChildByFieldName("name")
+	case "setter_signature":
+		return "setter", node.ChildByFieldName("name")
+	case "constructor_signature":
+		return "constructor", node.ChildByFieldName("name")
+	case "factory_constructor_signature":
+		// factory Foo.named() — first identifier child is the class name.
+		return "constructor", findChildByType(node, "identifier")
+	case "constant_constructor_signature":
+		return "constructor", findChildByType(node, "identifier")
+	}
+	return "", nil
+}
+
+func (e *symbolExtractor) extractImportDart(nodeType string, node *sitter.Node) (symbols.Import, bool) {
+	if nodeType != "import_or_export" {
+		return symbols.Import{}, false
+	}
+	// Dart: import 'package:foo/bar.dart';
+	// AST: import_or_export → library_import → import_specification → configurable_uri → uri → string_literal
+	// Walk descendants to find the configurable_uri node.
+	if uri := findDescendantByType(node, "configurable_uri"); uri != nil {
+		raw := strings.Trim(uri.Content(e.src), "'\"")
+		return symbols.Import{RawPath: raw, Language: e.lang}, true
+	}
+	// Fallback: use the full statement text.
+	return symbols.Import{RawPath: node.Content(e.src), Language: e.lang}, true
+}
+
+func (e *symbolExtractor) extractRefDart(nodeType string, node *sitter.Node) (symbols.Ref, bool) {
+	// Dart call expressions are encoded as sibling sequences under a parent
+	// (expression_statement, initialized_variable_definition, etc.):
+	//
+	//   Top-level call  print(x)        → identifier("print"),  selector(argument_part)
+	//   Method call     c.area()        → identifier("c"),  selector(.area),  selector(argument_part)
+	//   Constructor     Circle(5.0)     → identifier("Circle"), selector(argument_part)
+	//
+	// We trigger on a selector node that contains an argument_part (the "(…)").
+	// Then we look at the preceding sibling to determine the callee name.
+	if nodeType != "selector" || !hasChildOfType(node, "argument_part") {
+		return symbols.Ref{}, false
+	}
+
+	parent := node.Parent()
+	if parent == nil {
+		return symbols.Ref{}, false
+	}
+
+	// Find this node's index among its siblings.
+	idx := -1
+	for i := range int(parent.ChildCount()) {
+		if parent.Child(i) == node {
+			idx = i
+			break
+		}
+	}
+	if idx < 1 {
+		return symbols.Ref{}, false
+	}
+
+	prev := parent.Child(idx - 1)
+
+	// Case 1: Previous sibling is a selector with unconditional_assignable_selector
+	// → method call like c.area() — the ".area" selector precedes the "()" selector.
+	if prev.Type() == "selector" {
+		uas := findChildByType(prev, "unconditional_assignable_selector")
+		if uas != nil {
+			id := findChildByType(uas, "identifier")
+			if id != nil {
+				return symbols.Ref{
+					Name:     id.Content(e.src),
+					Line:     int(node.StartPoint().Row) + 1,
+					Language: e.lang,
+				}, true
+			}
+		}
+		return symbols.Ref{}, false
+	}
+
+	// Case 2: Previous sibling is an identifier → top-level / constructor call.
+	if prev.Type() == "identifier" {
+		name := prev.Content(e.src)
+		if name != "" {
+			return symbols.Ref{
+				Name:     name,
+				Line:     int(node.StartPoint().Row) + 1,
+				Language: e.lang,
+			}, true
+		}
+	}
+
+	return symbols.Ref{}, false
+}
+
 func (e *symbolExtractor) classifyGeneric(nodeType string, node *sitter.Node) (string, *sitter.Node) {
 	switch nodeType {
 	case "function_definition", "function_declaration":
@@ -951,7 +1105,7 @@ func (e *symbolExtractor) classifyGeneric(nodeType string, node *sitter.Node) (s
 
 func (e *symbolExtractor) extractSignature(node *sitter.Node, kind string) string {
 	switch kind {
-	case "function", "method":
+	case "function", "method", "constructor", "getter", "setter":
 		params := node.ChildByFieldName("parameters")
 		if params != nil {
 			return params.Content(e.src)
@@ -960,7 +1114,11 @@ func (e *symbolExtractor) extractSignature(node *sitter.Node, kind string) strin
 		if fvp := findChildByType(node, "function_value_parameters"); fvp != nil {
 			return fvp.Content(e.src)
 		}
-	case "struct", "class", "interface", "trait", "object", "enum":
+		// Dart grammar uses formal_parameter_list.
+		if fpl := findChildByType(node, "formal_parameter_list"); fpl != nil {
+			return fpl.Content(e.src)
+		}
+	case "struct", "class", "interface", "trait", "object", "enum", "mixin", "extension":
 		content := node.Content(e.src)
 		for i, ch := range content {
 			if ch == '\n' || ch == '{' {

--- a/internal/parser/parser.go
+++ b/internal/parser/parser.go
@@ -697,15 +697,18 @@ func findChildByType(node *sitter.Node, typeName string) *sitter.Node {
 
 // findDescendantByType returns the first descendant (BFS) with the given type.
 func findDescendantByType(node *sitter.Node, typeName string) *sitter.Node {
+	queue := make([]*sitter.Node, 0, int(node.ChildCount()))
 	for i := range int(node.ChildCount()) {
-		c := node.Child(i)
-		if c.Type() == typeName {
-			return c
-		}
+		queue = append(queue, node.Child(i))
 	}
-	for i := range int(node.ChildCount()) {
-		if found := findDescendantByType(node.Child(i), typeName); found != nil {
-			return found
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+		if current.Type() == typeName {
+			return current
+		}
+		for i := range int(current.ChildCount()) {
+			queue = append(queue, current.Child(i))
 		}
 	}
 	return nil
@@ -962,7 +965,9 @@ func protoNameNode(node *sitter.Node, childType string) *sitter.Node {
 }
 
 // dartInsideClassBody reports whether node sits inside a class_body,
-// enum_body, extension_body, or mixin body — i.e. its declaration is a member.
+// enum_body, or extension_body — i.e. its declaration is a member of a type.
+// Note: the Dart grammar uses class_body for mixin bodies too, so mixin
+// members are covered by the class_body check.
 func dartInsideClassBody(node *sitter.Node) bool {
 	p := node.Parent()
 	for p != nil {

--- a/internal/parser/parser_feature_test.go
+++ b/internal/parser/parser_feature_test.go
@@ -841,6 +841,184 @@ val GLOBAL = 42
 	}
 }
 
+// --- Dart Language Feature Tests ---
+
+func TestFeatureDartSymbols(t *testing.T) {
+	src := []byte(`import 'dart:core';
+import 'package:flutter/material.dart';
+
+typedef StringCallback = void Function(String value);
+
+mixin Printable {
+  void printSelf() {
+    print(toString());
+  }
+}
+
+enum Color { red, green, blue }
+
+abstract class Shape with Printable {
+  String get name;
+  set name(String value);
+
+  double area();
+
+  Shape();
+  Shape.origin() : this();
+}
+
+class Circle extends Shape {
+  final double radius;
+
+  Circle(this.radius);
+  factory Circle.unit() => Circle(1.0);
+
+  @override
+  String get name => 'circle';
+
+  @override
+  set name(String value) {}
+
+  @override
+  double area() {
+    return 3.14159 * radius * radius;
+  }
+}
+
+extension ShapeUtils on Shape {
+  bool isLargerThan(Shape other) {
+    return area() > other.area();
+  }
+}
+
+void main() {
+  final c = Circle(5.0);
+  c.area();
+  print(c.name);
+  doSomething();
+}
+
+void doSomething() {}
+`)
+	result, err := ParseSource(src, "test.dart", "dart", languages["dart"])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Debug: print all symbols if any assertion fails.
+	debugSymbols := func() {
+		t.Helper()
+		t.Log("=== All symbols ===")
+		for _, s := range result.Symbols {
+			t.Logf("  %s (%s) parent=%q depth=%d lines=%d-%d sig=%q",
+				s.Name, s.Kind, s.Parent, s.Depth, s.StartLine, s.EndLine, s.Signature)
+		}
+		t.Log("=== All imports ===")
+		for _, imp := range result.Imports {
+			t.Logf("  %s", imp.RawPath)
+		}
+		t.Log("=== All refs ===")
+		for _, ref := range result.Refs {
+			t.Logf("  %s (line %d)", ref.Name, ref.Line)
+		}
+	}
+
+	// --- Imports ---
+	if findImport(result.Imports, "dart:core") == nil {
+		debugSymbols()
+		t.Error("expected import 'dart:core'")
+	}
+	if findImport(result.Imports, "package:flutter/material.dart") == nil {
+		debugSymbols()
+		t.Error("expected import 'package:flutter/material.dart'")
+	}
+
+	// --- Type alias ---
+	if findSymbolKind(result.Symbols, "StringCallback", "type") == nil {
+		debugSymbols()
+		t.Error("expected StringCallback type alias")
+	}
+
+	// --- Mixin ---
+	if findSymbolKind(result.Symbols, "Printable", "mixin") == nil {
+		debugSymbols()
+		t.Error("expected Printable mixin")
+	}
+
+	// --- Enum ---
+	if findSymbolKind(result.Symbols, "Color", "enum") == nil {
+		debugSymbols()
+		t.Error("expected Color enum")
+	}
+
+	// --- Abstract class ---
+	if findSymbolKind(result.Symbols, "Shape", "class") == nil {
+		debugSymbols()
+		t.Error("expected Shape class")
+	}
+
+	// --- Concrete class ---
+	if findSymbolKind(result.Symbols, "Circle", "class") == nil {
+		debugSymbols()
+		t.Error("expected Circle class")
+	}
+
+	// --- Extension ---
+	if findSymbolKind(result.Symbols, "ShapeUtils", "extension") == nil {
+		debugSymbols()
+		t.Error("expected ShapeUtils extension")
+	}
+
+	// --- Methods inside class ---
+	areaSym := findSymbolKind(result.Symbols, "area", "method")
+	if areaSym == nil {
+		debugSymbols()
+		t.Fatal("expected area method")
+	}
+
+	// --- Top-level function ---
+	if findSymbolKind(result.Symbols, "main", "function") == nil {
+		debugSymbols()
+		t.Error("expected main function")
+	}
+	if findSymbolKind(result.Symbols, "doSomething", "function") == nil {
+		debugSymbols()
+		t.Error("expected doSomething function")
+	}
+
+	// --- Getters ---
+	// The Shape class declares `String get name;` — should be a getter.
+	nameSym := findSymbolKind(result.Symbols, "name", "getter")
+	if nameSym == nil {
+		debugSymbols()
+		t.Error("expected 'name' getter")
+	}
+
+	// --- Setters ---
+	nameSetSym := findSymbolKind(result.Symbols, "name", "setter")
+	if nameSetSym == nil {
+		debugSymbols()
+		t.Error("expected 'name' setter")
+	}
+
+	// --- Refs (function/method calls) ---
+	if findRef(result.Refs, "print") == nil {
+		debugSymbols()
+		t.Error("expected print ref")
+	}
+	if findRef(result.Refs, "area") == nil {
+		debugSymbols()
+		t.Error("expected area ref")
+	}
+
+	// --- Signature for functions ---
+	mainSym := findSymbol(result.Symbols, "main")
+	if mainSym == nil || mainSym.Signature == "" {
+		debugSymbols()
+		t.Error("expected non-empty signature for main function")
+	}
+}
+
 // --- Multi-language table-driven test ---
 
 func TestFeatureParseMultiLanguage(t *testing.T) {

--- a/internal/parser/parser_feature_test.go
+++ b/internal/parser/parser_feature_test.go
@@ -1001,6 +1001,38 @@ void doSomething() {}
 		t.Error("expected 'name' setter")
 	}
 
+	// --- Constructors ---
+	// Shape() and Shape.origin() both map to constructor kind with name "Shape".
+	if findSymbolKind(result.Symbols, "Shape", "constructor") == nil {
+		debugSymbols()
+		t.Error("expected Shape constructor")
+	}
+	// Circle(this.radius) and factory Circle.unit() both map to constructor kind.
+	if findSymbolKind(result.Symbols, "Circle", "constructor") == nil {
+		debugSymbols()
+		t.Error("expected Circle constructor")
+	}
+
+	// --- Mixin members ---
+	printSelfSym := findSymbolKind(result.Symbols, "printSelf", "method")
+	if printSelfSym == nil {
+		debugSymbols()
+		t.Fatal("expected printSelf method (mixin member)")
+	}
+	if printSelfSym.Parent != "Printable" {
+		t.Errorf("expected printSelf parent 'Printable', got %q", printSelfSym.Parent)
+	}
+
+	// --- Extension members ---
+	isLargerSym := findSymbolKind(result.Symbols, "isLargerThan", "method")
+	if isLargerSym == nil {
+		debugSymbols()
+		t.Fatal("expected isLargerThan method (extension member)")
+	}
+	if isLargerSym.Parent != "ShapeUtils" {
+		t.Errorf("expected isLargerThan parent 'ShapeUtils', got %q", isLargerSym.Parent)
+	}
+
 	// --- Refs (function/method calls) ---
 	if findRef(result.Refs, "print") == nil {
 		debugSymbols()
@@ -1011,11 +1043,21 @@ void doSomething() {}
 		t.Error("expected area ref")
 	}
 
-	// --- Signature for functions ---
+	// --- Signatures ---
+	// Functions have a formal_parameter_list signature.
 	mainSym := findSymbol(result.Symbols, "main")
 	if mainSym == nil || mainSym.Signature == "" {
 		debugSymbols()
 		t.Error("expected non-empty signature for main function")
+	}
+	// Setters carry their single parameter as a signature.
+	if nameSetSym != nil && nameSetSym.Signature == "" {
+		t.Error("expected non-empty signature for name setter")
+	}
+	// Constructor with a parameter list should have a signature.
+	circleCtor := findSymbolKind(result.Symbols, "Circle", "constructor")
+	if circleCtor == nil || circleCtor.Signature == "" {
+		t.Error("expected non-empty signature for Circle constructor")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds Dart (`.dart`) language support to cymbal using the `UserNobody14/tree-sitter-dart` grammar, following the same pattern as the Kotlin contribution (#7).
- Dart is a widely-used language (Flutter, server-side) with no prior cymbal support; `.dart` file extension was already mapped in `walker.go` but the parser had no Dart implementation.

## Testing

- Commands run:
  - `CGO_CFLAGS="-DSQLITE_ENABLE_FTS5" go test ./...`
- Extra validation:
  - Ran `TestFeatureDartSymbols` (new test) covering classes, enums, mixins, extensions, type aliases, functions, methods, getters, setters, constructors, imports, and refs — all pass.
  - Verified ABI compatibility: `UserNobody14/tree-sitter-dart` master uses ABI v15 (incompatible); pinned to commit `8197a31` (2024-08-31) which is ABI v14, matching `smacker/go-tree-sitter`'s supported range.

## Checklist

- [x] I ran the required checks locally, or I explained why I could not in the Testing section.
- [x] I reviewed the diff for unrelated, generated, or vendored changes.
- [x] I updated docs, benchmarks, or release notes when behavior changed, or I explained why no updates were needed.
- [x] I filled out the Security Notes and Risks / Rollout sections below.

## Security Notes

- User input, file parsing, shell execution, or network behavior touched: File parsing only — Dart source files are parsed via tree-sitter (same sandboxed AST parsing used by all other languages).
- New dependencies or vendored code added: One new Go module dependency `github.com/UserNobody14/tree-sitter-dart v0.0.0-20240901045915-8197a3123420` (tree-sitter grammar, no vendored C files in this repo).
- Secrets, credentials, or tokens touched: None.
- Follow-up needed: None.

## Risks / Rollout

- Risk level: Low — additive change only; existing language support is unaffected. Dart parsing is gated behind the `"dart"` language key, same as all other languages.
- Rollback plan: Revert the single commit; remove the `tree-sitter-dart` dependency from `go.mod`.