### PR TITLE
feat(parser): add C/C++ call-site reference extraction

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -302,7 +302,7 @@ func (e *symbolExtractor) extractRef(node *sitter.Node) (symbols.Ref, bool) {
 	nodeType := node.Type()
 
 	switch e.lang {
-	case "go", "javascript", "typescript", "rust":
+	case "go", "javascript", "typescript", "rust", "c", "cpp":
 		return e.extractRefCallExpr(nodeType, node)
 	case "python":
 		return e.extractRefPythonCall(nodeType, node)
@@ -414,10 +414,15 @@ func (e *symbolExtractor) extractRefElixir(nodeType string, node *sitter.Node) (
 
 // extractCallName gets the final identifier from a call expression function node.
 // For "foo.bar.Baz()", returns "Baz". For "Baz()", returns "Baz".
+// For C++ qualified names like "Calculator::multiply()", returns "multiply".
 func extractCallName(node *sitter.Node, src []byte) string {
 	content := node.Content(src)
 	if dot := strings.LastIndex(content, "."); dot >= 0 {
 		return content[dot+1:]
+	}
+	// C++ scope-resolution operator (e.g., Calculator::multiply, std::sort).
+	if sep := strings.LastIndex(content, "::"); sep >= 0 {
+		return content[sep+2:]
 	}
 	// Skip if it contains special characters (not a simple identifier).
 	if strings.ContainsAny(content, "()[]{}") {

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -418,20 +418,40 @@ func (e *symbolExtractor) extractRefElixir(nodeType string, node *sitter.Node) (
 //   - "Calculator::multiply()" -> "multiply"
 //   - "ptr->method()" -> "method"
 func extractCallName(node *sitter.Node, src []byte, lang string) string {
-	content := node.Content(src)
-	if dot := strings.LastIndex(content, "."); dot >= 0 {
-		return content[dot+1:]
-	}
-	if lang == "cpp" {
-		// C++ member access via pointer (e.g., ptr->method).
-		if arrow := strings.LastIndex(content, "->"); arrow >= 0 {
-			return content[arrow+2:]
+	content := strings.TrimSpace(node.Content(src))
+
+	if lang == "c" || lang == "cpp" {
+		// Normalize chained C/C++ qualifiers to the final callable name.
+		// Handles separators like ., ->, and :: in mixed forms.
+		for {
+			idx, step := -1, 0
+			if dot := strings.LastIndex(content, "."); dot > idx {
+				idx, step = dot, 1
+			}
+			if arrow := strings.LastIndex(content, "->"); arrow > idx {
+				idx, step = arrow, 2
+			}
+			if sep := strings.LastIndex(content, "::"); sep > idx {
+				idx, step = sep, 2
+			}
+			if idx < 0 {
+				break
+			}
+			content = content[idx+step:]
 		}
-		// C++ scope-resolution operator (e.g., Calculator::multiply).
-		if sep := strings.LastIndex(content, "::"); sep >= 0 {
-			return content[sep+2:]
+
+		// C++ template calls (e.g., std::max<int>) should resolve to max.
+		if lang == "cpp" {
+			if lt := strings.Index(content, "<"); lt > 0 && strings.HasSuffix(content, ">") {
+				content = content[:lt]
+			}
+		}
+	} else {
+		if dot := strings.LastIndex(content, "."); dot >= 0 {
+			content = content[dot+1:]
 		}
 	}
+
 	// Skip if it contains special characters (not a simple identifier).
 	if strings.ContainsAny(content, "()[]{}") {
 		return ""

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -326,7 +326,7 @@ func (e *symbolExtractor) extractRefCallExpr(nodeType string, node *sitter.Node)
 	}
 	funcNode := node.ChildByFieldName("function")
 	if funcNode != nil {
-		name := extractCallName(funcNode, e.src)
+		name := extractCallName(funcNode, e.src, e.lang)
 		if name != "" {
 			return symbols.Ref{Name: name, Line: int(node.StartPoint().Row) + 1, Language: e.lang}, true
 		}
@@ -340,7 +340,7 @@ func (e *symbolExtractor) extractRefPythonCall(nodeType string, node *sitter.Nod
 	}
 	funcNode := node.ChildByFieldName("function")
 	if funcNode != nil {
-		name := extractCallName(funcNode, e.src)
+		name := extractCallName(funcNode, e.src, e.lang)
 		if name != "" {
 			return symbols.Ref{Name: name, Line: int(node.StartPoint().Row) + 1, Language: e.lang}, true
 		}
@@ -376,7 +376,7 @@ func (e *symbolExtractor) extractRefKotlin(nodeType string, node *sitter.Node) (
 	}
 	if node.ChildCount() > 0 {
 		callee := node.Child(0)
-		name := extractCallName(callee, e.src)
+		name := extractCallName(callee, e.src, e.lang)
 		if name != "" {
 			return symbols.Ref{Name: name, Line: int(node.StartPoint().Row) + 1, Language: e.lang}, true
 		}
@@ -414,15 +414,23 @@ func (e *symbolExtractor) extractRefElixir(nodeType string, node *sitter.Node) (
 
 // extractCallName gets the final identifier from a call expression function node.
 // For "foo.bar.Baz()", returns "Baz". For "Baz()", returns "Baz".
-// For C++ qualified names like "Calculator::multiply()", returns "multiply".
-func extractCallName(node *sitter.Node, src []byte) string {
+// C++ extras (when lang == "cpp"):
+//   - "Calculator::multiply()" -> "multiply"
+//   - "ptr->method()" -> "method"
+func extractCallName(node *sitter.Node, src []byte, lang string) string {
 	content := node.Content(src)
 	if dot := strings.LastIndex(content, "."); dot >= 0 {
 		return content[dot+1:]
 	}
-	// C++ scope-resolution operator (e.g., Calculator::multiply, std::sort).
-	if sep := strings.LastIndex(content, "::"); sep >= 0 {
-		return content[sep+2:]
+	if lang == "cpp" {
+		// C++ member access via pointer (e.g., ptr->method).
+		if arrow := strings.LastIndex(content, "->"); arrow >= 0 {
+			return content[arrow+2:]
+		}
+		// C++ scope-resolution operator (e.g., Calculator::multiply).
+		if sep := strings.LastIndex(content, "::"); sep >= 0 {
+			return content[sep+2:]
+		}
 	}
 	// Skip if it contains special characters (not a simple identifier).
 	if strings.ContainsAny(content, "()[]{}") {

--- a/parser/parser_feature_test.go
+++ b/parser/parser_feature_test.go
@@ -1095,6 +1095,16 @@ enum Color { RED, GREEN, BLUE };
 
 typedef unsigned long ulong;
 
+typedef int (*op_t)(int);
+
+int double_it(int x) {
+    return x * 2;
+}
+
+struct FnBox {
+    op_t cb;
+};
+
 int add(int a, int b) {
     return a + b;
 }
@@ -1105,6 +1115,13 @@ int main() {
     int result = add(1, 2);
     helper(result);
     printf("result = %d\n", result);
+
+    struct FnBox box;
+    box.cb = double_it;
+    box.cb(7);
+    struct FnBox *boxPtr = &box;
+    boxPtr->cb(8);
+
     int *p = malloc(sizeof(int));
     free(p);
     return 0;
@@ -1197,12 +1214,21 @@ int main() {
 		debugSymbols()
 		t.Error("expected ref to 'free'")
 	}
+	if findRef(result.Refs, "cb") == nil {
+		debugSymbols()
+		t.Error("expected ref to 'cb' from function-pointer field calls")
+	}
+	if findRef(result.Refs, "boxPtr->cb") != nil {
+		debugSymbols()
+		t.Error("expected pointer call to normalize to 'cb', got raw 'boxPtr->cb'")
+	}
 }
 
 // --- C++ Language Feature Tests ---
 
 func TestFeatureCPPRefs(t *testing.T) {
 	src := []byte(`#include <iostream>
+#include <algorithm>
 #include <vector>
 
 struct Point { int x; int y; };
@@ -1230,6 +1256,7 @@ int main() {
     int sum = calc.add(1, 2);
     int diff = ptr->subtract(9, 3);
     int product = Calculator::multiply(3, 4);
+    int mx = std::max<int>(1, 2);
     utils::helper(sum);
     standalone();
     printf("done");
@@ -1318,6 +1345,16 @@ int main() {
 	if findRef(result.Refs, "multiply") == nil {
 		debugSymbols()
 		t.Error("expected ref to 'multiply' (qualified call via ::)")
+	}
+
+	// Template call should normalize to the base callable name.
+	if findRef(result.Refs, "max") == nil {
+		debugSymbols()
+		t.Error("expected template call ref to normalize to 'max'")
+	}
+	if findRef(result.Refs, "max<int>") != nil {
+		debugSymbols()
+		t.Error("expected no raw template ref name 'max<int>'")
 	}
 
 	// Namespace-scoped call: utils::helper(sum) should extract "helper".

--- a/parser/parser_feature_test.go
+++ b/parser/parser_feature_test.go
@@ -703,6 +703,28 @@ impl Circle {
 	}
 }
 
+func TestFeatureRustScopedCallRef(t *testing.T) {
+	src := []byte(`fn helper() {}
+
+fn main() {
+    let v = 1;
+    std::mem::drop(v);
+    helper();
+}
+`)
+	result, err := ParseSource(src, "test.rs", "rust", languages["rust"])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if findRef(result.Refs, "std::mem::drop") == nil {
+		t.Fatal("expected scoped rust ref 'std::mem::drop'")
+	}
+	if findRef(result.Refs, "helper") == nil {
+		t.Fatal("expected helper ref")
+	}
+}
+
 // --- Kotlin Language Feature Tests ---
 
 func TestFeatureKotlinSymbols(t *testing.T) {
@@ -1147,7 +1169,7 @@ int main() {
 		t.Error("expected main function")
 	}
 
-	// --- Refs (call-site extraction — the new feature) ---
+	// --- Refs (call-site extraction, new feature) ---
 	addRef := findRef(result.Refs, "add")
 	if addRef == nil {
 		debugSymbols()
@@ -1192,6 +1214,7 @@ typedef unsigned long ulong;
 class Calculator {
 public:
     int add(int a, int b) { return a + b; }
+    int subtract(int a, int b) { return a - b; }
     static int multiply(int a, int b) { return a * b; }
 };
 
@@ -1203,7 +1226,9 @@ void standalone() {}
 
 int main() {
     Calculator calc;
+    Calculator* ptr = &calc;
     int sum = calc.add(1, 2);
+    int diff = ptr->subtract(9, 3);
     int product = Calculator::multiply(3, 4);
     utils::helper(sum);
     standalone();
@@ -1266,14 +1291,14 @@ int main() {
 		t.Error("expected main function")
 	}
 
-	// --- Refs (call-site extraction — the new feature) ---
+	// --- Refs (call-site extraction, new feature) ---
 	// Simple function call.
 	if findRef(result.Refs, "standalone") == nil {
 		debugSymbols()
 		t.Error("expected ref to 'standalone'")
 	}
 
-	// Method call via dot: calc.add(1, 2) → ref to "add".
+	// Method call via dot: calc.add(1, 2) should extract "add".
 	addRef := findRef(result.Refs, "add")
 	if addRef == nil {
 		debugSymbols()
@@ -1283,13 +1308,19 @@ int main() {
 		t.Error("expected non-zero line for add ref")
 	}
 
-	// Static method call via :: scope: Calculator::multiply(3, 4) → ref to "multiply".
+	// Method call via pointer: ptr->subtract(9, 3) should extract "subtract".
+	if findRef(result.Refs, "subtract") == nil {
+		debugSymbols()
+		t.Error("expected ref to 'subtract' (pointer call via ->)")
+	}
+
+	// Static method call via :: scope: Calculator::multiply(3, 4) should extract "multiply".
 	if findRef(result.Refs, "multiply") == nil {
 		debugSymbols()
 		t.Error("expected ref to 'multiply' (qualified call via ::)")
 	}
 
-	// Namespace-scoped call: utils::helper(sum) → ref to "helper".
+	// Namespace-scoped call: utils::helper(sum) should extract "helper".
 	if findRef(result.Refs, "helper") == nil {
 		debugSymbols()
 		t.Error("expected ref to 'helper' (namespace-scoped call via ::)")

--- a/parser/parser_feature_test.go
+++ b/parser/parser_feature_test.go
@@ -1061,6 +1061,247 @@ void doSomething() {}
 	}
 }
 
+// --- C Language Feature Tests ---
+
+func TestFeatureCRefs(t *testing.T) {
+	src := []byte(`#include <stdio.h>
+#include <stdlib.h>
+
+struct Point { int x; int y; };
+
+enum Color { RED, GREEN, BLUE };
+
+typedef unsigned long ulong;
+
+int add(int a, int b) {
+    return a + b;
+}
+
+void helper(int x) {}
+
+int main() {
+    int result = add(1, 2);
+    helper(result);
+    printf("result = %d\n", result);
+    int *p = malloc(sizeof(int));
+    free(p);
+    return 0;
+}
+`)
+	result, err := ParseSource(src, "test.c", "c", languages["c"])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Debug: print all symbols if any assertion fails.
+	debugSymbols := func() {
+		t.Helper()
+		t.Log("=== All symbols ===")
+		for _, s := range result.Symbols {
+			t.Logf("  %s (%s) parent=%q lines=%d-%d",
+				s.Name, s.Kind, s.Parent, s.StartLine, s.EndLine)
+		}
+		t.Log("=== All imports ===")
+		for _, imp := range result.Imports {
+			t.Logf("  %s", imp.RawPath)
+		}
+		t.Log("=== All refs ===")
+		for _, ref := range result.Refs {
+			t.Logf("  %s (line %d)", ref.Name, ref.Line)
+		}
+	}
+
+	// --- Imports ---
+	if findImport(result.Imports, "stdio.h") == nil {
+		debugSymbols()
+		t.Error("expected import 'stdio.h'")
+	}
+	if findImport(result.Imports, "stdlib.h") == nil {
+		debugSymbols()
+		t.Error("expected import 'stdlib.h'")
+	}
+
+	// --- Symbols (existing classifyC coverage) ---
+	if findSymbolKind(result.Symbols, "Point", "struct") == nil {
+		debugSymbols()
+		t.Error("expected Point struct")
+	}
+	if findSymbolKind(result.Symbols, "Color", "enum") == nil {
+		debugSymbols()
+		t.Error("expected Color enum")
+	}
+	if findSymbolKind(result.Symbols, "ulong", "type") == nil {
+		debugSymbols()
+		t.Error("expected ulong typedef")
+	}
+	if findSymbolKind(result.Symbols, "add", "function") == nil {
+		debugSymbols()
+		t.Error("expected add function")
+	}
+	if findSymbolKind(result.Symbols, "helper", "function") == nil {
+		debugSymbols()
+		t.Error("expected helper function")
+	}
+	if findSymbolKind(result.Symbols, "main", "function") == nil {
+		debugSymbols()
+		t.Error("expected main function")
+	}
+
+	// --- Refs (call-site extraction — the new feature) ---
+	addRef := findRef(result.Refs, "add")
+	if addRef == nil {
+		debugSymbols()
+		t.Fatal("expected ref to 'add'")
+	}
+	if addRef.Line == 0 {
+		t.Error("expected non-zero line for add ref")
+	}
+
+	helperRef := findRef(result.Refs, "helper")
+	if helperRef == nil {
+		debugSymbols()
+		t.Fatal("expected ref to 'helper'")
+	}
+
+	if findRef(result.Refs, "printf") == nil {
+		debugSymbols()
+		t.Error("expected ref to 'printf'")
+	}
+	if findRef(result.Refs, "malloc") == nil {
+		debugSymbols()
+		t.Error("expected ref to 'malloc'")
+	}
+	if findRef(result.Refs, "free") == nil {
+		debugSymbols()
+		t.Error("expected ref to 'free'")
+	}
+}
+
+// --- C++ Language Feature Tests ---
+
+func TestFeatureCPPRefs(t *testing.T) {
+	src := []byte(`#include <iostream>
+#include <vector>
+
+struct Point { int x; int y; };
+
+enum Color { RED, GREEN, BLUE };
+
+typedef unsigned long ulong;
+
+class Calculator {
+public:
+    int add(int a, int b) { return a + b; }
+    static int multiply(int a, int b) { return a * b; }
+};
+
+namespace utils {
+    void helper(int x) {}
+}
+
+void standalone() {}
+
+int main() {
+    Calculator calc;
+    int sum = calc.add(1, 2);
+    int product = Calculator::multiply(3, 4);
+    utils::helper(sum);
+    standalone();
+    printf("done");
+    return 0;
+}
+`)
+	result, err := ParseSource(src, "test.cpp", "cpp", languages["cpp"])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Debug: print all symbols if any assertion fails.
+	debugSymbols := func() {
+		t.Helper()
+		t.Log("=== All symbols ===")
+		for _, s := range result.Symbols {
+			t.Logf("  %s (%s) parent=%q lines=%d-%d",
+				s.Name, s.Kind, s.Parent, s.StartLine, s.EndLine)
+		}
+		t.Log("=== All imports ===")
+		for _, imp := range result.Imports {
+			t.Logf("  %s", imp.RawPath)
+		}
+		t.Log("=== All refs ===")
+		for _, ref := range result.Refs {
+			t.Logf("  %s (line %d)", ref.Name, ref.Line)
+		}
+	}
+
+	// --- Imports ---
+	if findImport(result.Imports, "iostream") == nil {
+		debugSymbols()
+		t.Error("expected import 'iostream'")
+	}
+	if findImport(result.Imports, "vector") == nil {
+		debugSymbols()
+		t.Error("expected import 'vector'")
+	}
+
+	// --- Symbols (existing classifyC coverage for C++) ---
+	if findSymbolKind(result.Symbols, "Point", "struct") == nil {
+		debugSymbols()
+		t.Error("expected Point struct")
+	}
+	if findSymbolKind(result.Symbols, "Color", "enum") == nil {
+		debugSymbols()
+		t.Error("expected Color enum")
+	}
+	if findSymbolKind(result.Symbols, "ulong", "type") == nil {
+		debugSymbols()
+		t.Error("expected ulong typedef")
+	}
+	if findSymbolKind(result.Symbols, "standalone", "function") == nil {
+		debugSymbols()
+		t.Error("expected standalone function")
+	}
+	if findSymbolKind(result.Symbols, "main", "function") == nil {
+		debugSymbols()
+		t.Error("expected main function")
+	}
+
+	// --- Refs (call-site extraction — the new feature) ---
+	// Simple function call.
+	if findRef(result.Refs, "standalone") == nil {
+		debugSymbols()
+		t.Error("expected ref to 'standalone'")
+	}
+
+	// Method call via dot: calc.add(1, 2) → ref to "add".
+	addRef := findRef(result.Refs, "add")
+	if addRef == nil {
+		debugSymbols()
+		t.Fatal("expected ref to 'add' (method call via dot)")
+	}
+	if addRef.Line == 0 {
+		t.Error("expected non-zero line for add ref")
+	}
+
+	// Static method call via :: scope: Calculator::multiply(3, 4) → ref to "multiply".
+	if findRef(result.Refs, "multiply") == nil {
+		debugSymbols()
+		t.Error("expected ref to 'multiply' (qualified call via ::)")
+	}
+
+	// Namespace-scoped call: utils::helper(sum) → ref to "helper".
+	if findRef(result.Refs, "helper") == nil {
+		debugSymbols()
+		t.Error("expected ref to 'helper' (namespace-scoped call via ::)")
+	}
+
+	// Plain C-style call in C++ context.
+	if findRef(result.Refs, "printf") == nil {
+		debugSymbols()
+		t.Error("expected ref to 'printf'")
+	}
+}
+
 // --- Multi-language table-driven test ---
 
 func TestFeatureParseMultiLanguage(t *testing.T) {


### PR DESCRIPTION
## Summary

- Adds call-site reference extraction for C and C++ by routing both languages through the existing `extractRefCallExpr` handler in `parser.go`. Previously, C and C++ were completely absent from the `extractRef` switch, meaning `cymbal refs`, `impact`, `trace`, and `investigate` returned no call-graph data for these languages.
- Extends call-name normalization for C/C++ so refs store the final callable identifier across chained separators (`.`, `->`, `::`).
- Adds C++ template call normalization so calls like `std::max<int>(...)` resolve to `max`.
- Preserves existing Rust scoped-call behavior (`std::mem::drop`) by keeping C++ specific parsing scoped to C/C++ code paths.

## Testing

- Commands run:
  - `CGO_CFLAGS="-DSQLITE_ENABLE_FTS5" go test ./...`
  - `CGO_CFLAGS="-DSQLITE_ENABLE_FTS5" go vet ./...`
  - `CGO_CFLAGS="-DSQLITE_ENABLE_FTS5" go build -o /dev/null .`
- Extra validation:
  - `TestFeatureCRefs` covers direct calls (`add`, `helper`), stdlib calls (`printf`, `malloc`, `free`), and function-pointer field calls (`box.cb(...)`, `boxPtr->cb(...)`) with normalization assertions.
  - `TestFeatureCPPRefs` covers simple calls (`standalone()`, `printf()`), dot calls (`calc.add(...)`), pointer calls (`ptr->subtract(...)`), qualified calls (`Calculator::multiply(...)`, `utils::helper(...)`), and template calls (`std::max<int>(...)`) with normalization assertions.
  - `TestFeatureRustScopedCallRef` ensures Rust scoped refs remain unchanged (`std::mem::drop`).
  - Real-life CLI validation on a temporary sample C/C++ repo:
    - `refs cb` returns both dot and pointer C call sites
    - `refs subtract` returns C++ pointer call site
    - `refs max` returns C++ template call site
    - `refs boxPtr->cb` and `refs max<int>` return no matches (normalized as expected)
    - `trace main --depth 2` shows expected C/C++ callees
  - Full suite passes.

## Checklist

- [x] I ran the required checks locally, or I explained why I could not in the Testing section.
- [x] I reviewed the diff for unrelated, generated, or vendored changes.
- [x] I updated docs, benchmarks, or release notes when behavior changed, or I explained why no updates were needed.
- [x] I filled out the Security Notes and Risks / Rollout sections below.

## Security Notes

- User input, file parsing, shell execution, or network behavior touched: File parsing only. C/C++ source files are parsed via tree-sitter, same as all existing languages.
- New dependencies or vendored code added: None.
- Secrets, credentials, or tokens touched: None.
- Follow-up needed: None.

## Risks / Rollout

- Risk level: Low. This is additive support plus normalization hardening for C/C++ refs. Existing non C/C++ behavior remains unchanged.
- Rollback plan: Revert the PR commits; no dependency changes required.
