### PR TITLE
fix(parser): extract refs from Go composite literals and JS/TS new expressions

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -373,22 +373,50 @@ func (e *symbolExtractor) extractRefGoCompositeLiteral(nodeType string, node *si
 		// map[KeyType]ValueType — emit refs for named key and value types
 		keyNode := typeNode.ChildByFieldName("key")
 		valNode := typeNode.ChildByFieldName("value")
-		if keyNode != nil && keyNode.Type() == "type_identifier" {
-			e.refs = append(e.refs, symbols.Ref{Name: keyNode.Content(e.src), Line: line, Language: e.lang})
+		if keyNode != nil {
+			switch keyNode.Type() {
+			case "type_identifier":
+				e.refs = append(e.refs, symbols.Ref{Name: keyNode.Content(e.src), Line: line, Language: e.lang})
+			case "qualified_type":
+				if nameNode := keyNode.ChildByFieldName("name"); nameNode != nil {
+					e.refs = append(e.refs, symbols.Ref{Name: nameNode.Content(e.src), Line: line, Language: e.lang})
+				}
+			}
 		}
-		if valNode != nil && valNode.Type() == "type_identifier" {
-			return symbols.Ref{Name: valNode.Content(e.src), Line: line, Language: e.lang}, true
+		if valNode != nil {
+			switch valNode.Type() {
+			case "type_identifier":
+				return symbols.Ref{Name: valNode.Content(e.src), Line: line, Language: e.lang}, true
+			case "qualified_type":
+				if nameNode := valNode.ChildByFieldName("name"); nameNode != nil {
+					return symbols.Ref{Name: nameNode.Content(e.src), Line: line, Language: e.lang}, true
+				}
+			}
 		}
 	case "slice_type":
 		// []TypeName{} — extract TypeName
 		elemNode := typeNode.ChildByFieldName("element")
-		if elemNode != nil && elemNode.Type() == "type_identifier" {
-			return symbols.Ref{Name: elemNode.Content(e.src), Line: line, Language: e.lang}, true
+		if elemNode != nil {
+			switch elemNode.Type() {
+			case "type_identifier":
+				return symbols.Ref{Name: elemNode.Content(e.src), Line: line, Language: e.lang}, true
+			case "qualified_type":
+				if nameNode := elemNode.ChildByFieldName("name"); nameNode != nil {
+					return symbols.Ref{Name: nameNode.Content(e.src), Line: line, Language: e.lang}, true
+				}
+			}
 		}
 	case "array_type":
 		elemNode := typeNode.ChildByFieldName("element")
-		if elemNode != nil && elemNode.Type() == "type_identifier" {
-			return symbols.Ref{Name: elemNode.Content(e.src), Line: line, Language: e.lang}, true
+		if elemNode != nil {
+			switch elemNode.Type() {
+			case "type_identifier":
+				return symbols.Ref{Name: elemNode.Content(e.src), Line: line, Language: e.lang}, true
+			case "qualified_type":
+				if nameNode := elemNode.ChildByFieldName("name"); nameNode != nil {
+					return symbols.Ref{Name: nameNode.Content(e.src), Line: line, Language: e.lang}, true
+				}
+			}
 		}
 	}
 	return symbols.Ref{}, false

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -302,7 +302,17 @@ func (e *symbolExtractor) extractRef(node *sitter.Node) (symbols.Ref, bool) {
 	nodeType := node.Type()
 
 	switch e.lang {
-	case "go", "javascript", "typescript", "rust", "c", "cpp":
+	case "go":
+		if ref, ok := e.extractRefCallExpr(nodeType, node); ok {
+			return ref, true
+		}
+		return e.extractRefGoCompositeLiteral(nodeType, node)
+	case "javascript", "typescript":
+		if ref, ok := e.extractRefCallExpr(nodeType, node); ok {
+			return ref, true
+		}
+		return e.extractRefNewExpr(nodeType, node)
+	case "rust", "c", "cpp":
 		return e.extractRefCallExpr(nodeType, node)
 	case "python":
 		return e.extractRefPythonCall(nodeType, node)
@@ -327,6 +337,70 @@ func (e *symbolExtractor) extractRefCallExpr(nodeType string, node *sitter.Node)
 	funcNode := node.ChildByFieldName("function")
 	if funcNode != nil {
 		name := extractCallName(funcNode, e.src, e.lang)
+		if name != "" {
+			return symbols.Ref{Name: name, Line: int(node.StartPoint().Row) + 1, Language: e.lang}, true
+		}
+	}
+	return symbols.Ref{}, false
+}
+
+func (e *symbolExtractor) extractRefGoCompositeLiteral(nodeType string, node *sitter.Node) (symbols.Ref, bool) {
+	if nodeType != "composite_literal" {
+		return symbols.Ref{}, false
+	}
+	typeNode := node.ChildByFieldName("type")
+	if typeNode == nil {
+		return symbols.Ref{}, false
+	}
+	line := int(node.StartPoint().Row) + 1
+
+	switch typeNode.Type() {
+	case "type_identifier":
+		name := typeNode.Content(e.src)
+		if name != "" {
+			return symbols.Ref{Name: name, Line: line, Language: e.lang}, true
+		}
+	case "qualified_type":
+		// e.g. pkg.StructName — extract StructName
+		nameNode := typeNode.ChildByFieldName("name")
+		if nameNode != nil {
+			name := nameNode.Content(e.src)
+			if name != "" {
+				return symbols.Ref{Name: name, Line: line, Language: e.lang}, true
+			}
+		}
+	case "map_type":
+		// map[KeyType]ValueType — emit refs for named key and value types
+		keyNode := typeNode.ChildByFieldName("key")
+		valNode := typeNode.ChildByFieldName("value")
+		if keyNode != nil && keyNode.Type() == "type_identifier" {
+			e.refs = append(e.refs, symbols.Ref{Name: keyNode.Content(e.src), Line: line, Language: e.lang})
+		}
+		if valNode != nil && valNode.Type() == "type_identifier" {
+			return symbols.Ref{Name: valNode.Content(e.src), Line: line, Language: e.lang}, true
+		}
+	case "slice_type":
+		// []TypeName{} — extract TypeName
+		elemNode := typeNode.ChildByFieldName("element")
+		if elemNode != nil && elemNode.Type() == "type_identifier" {
+			return symbols.Ref{Name: elemNode.Content(e.src), Line: line, Language: e.lang}, true
+		}
+	case "array_type":
+		elemNode := typeNode.ChildByFieldName("element")
+		if elemNode != nil && elemNode.Type() == "type_identifier" {
+			return symbols.Ref{Name: elemNode.Content(e.src), Line: line, Language: e.lang}, true
+		}
+	}
+	return symbols.Ref{}, false
+}
+
+func (e *symbolExtractor) extractRefNewExpr(nodeType string, node *sitter.Node) (symbols.Ref, bool) {
+	if nodeType != "new_expression" {
+		return symbols.Ref{}, false
+	}
+	ctorNode := node.ChildByFieldName("constructor")
+	if ctorNode != nil {
+		name := extractCallName(ctorNode, e.src, e.lang)
 		if name != "" {
 			return symbols.Ref{Name: name, Line: int(node.StartPoint().Row) + 1, Language: e.lang}, true
 		}

--- a/parser/parser_feature_test.go
+++ b/parser/parser_feature_test.go
@@ -1597,6 +1597,78 @@ func main() {
 	}
 }
 
+func TestFeatureGoQualifiedMapLiteralRef(t *testing.T) {
+	src := []byte(`package main
+
+import "pkg"
+
+func main() {
+	m := map[pkg.Key]pkg.Value{}
+	_ = m
+}
+`)
+	result, err := ParseSource(src, "test.go", "go", languages["go"])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	keyRef := findRef(result.Refs, "Key")
+	if keyRef == nil {
+		debugParseResult(t, result)
+		t.Fatal("expected to find Key ref from qualified map key type")
+	}
+
+	valRef := findRef(result.Refs, "Value")
+	if valRef == nil {
+		debugParseResult(t, result)
+		t.Fatal("expected to find Value ref from qualified map value type")
+	}
+}
+
+func TestFeatureGoQualifiedSliceLiteralRef(t *testing.T) {
+	src := []byte(`package main
+
+import "pkg"
+
+func main() {
+	items := []pkg.Item{}
+	_ = items
+}
+`)
+	result, err := ParseSource(src, "test.go", "go", languages["go"])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ref := findRef(result.Refs, "Item")
+	if ref == nil {
+		debugParseResult(t, result)
+		t.Fatal("expected to find Item ref from qualified slice element type")
+	}
+}
+
+func TestFeatureGoQualifiedArrayLiteralRef(t *testing.T) {
+	src := []byte(`package main
+
+import "pkg"
+
+func main() {
+	items := [3]pkg.Item{}
+	_ = items
+}
+`)
+	result, err := ParseSource(src, "test.go", "go", languages["go"])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ref := findRef(result.Refs, "Item")
+	if ref == nil {
+		debugParseResult(t, result)
+		t.Fatal("expected to find Item ref from qualified array element type")
+	}
+}
+
 // --- JS/TS New Expression Ref Tests ---
 
 func TestFeatureJSNewExpressionRef(t *testing.T) {

--- a/parser/parser_feature_test.go
+++ b/parser/parser_feature_test.go
@@ -1495,3 +1495,170 @@ func Third() {}
 		t.Error("Second should come before Third")
 	}
 }
+
+// --- Go Composite Literal Ref Tests ---
+
+func TestFeatureGoCompositeLiteralRef(t *testing.T) {
+	src := []byte(`package main
+
+type UsedStruct struct {
+	Name string
+}
+
+func main() {
+	s := UsedStruct{Name: "foo"}
+	_ = s
+}
+`)
+	result, err := ParseSource(src, "test.go", "go", languages["go"])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ref := findRef(result.Refs, "UsedStruct")
+	if ref == nil {
+		debugParseResult(t, result)
+		t.Fatal("expected to find UsedStruct ref from composite literal")
+	}
+	if ref.Line != 8 {
+		t.Errorf("expected UsedStruct ref on line 8, got %d", ref.Line)
+	}
+}
+
+func TestFeatureGoMapLiteralRef(t *testing.T) {
+	src := []byte(`package main
+
+type MyKey string
+type MyValue int
+
+func main() {
+	m := map[MyKey]MyValue{}
+	_ = m
+}
+`)
+	result, err := ParseSource(src, "test.go", "go", languages["go"])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	keyRef := findRef(result.Refs, "MyKey")
+	if keyRef == nil {
+		debugParseResult(t, result)
+		t.Fatal("expected to find MyKey ref from map composite literal")
+	}
+
+	valRef := findRef(result.Refs, "MyValue")
+	if valRef == nil {
+		debugParseResult(t, result)
+		t.Fatal("expected to find MyValue ref from map composite literal")
+	}
+}
+
+func TestFeatureGoSliceLiteralRef(t *testing.T) {
+	src := []byte(`package main
+
+type Item struct{ V int }
+
+func main() {
+	items := []Item{{V: 1}, {V: 2}}
+	_ = items
+}
+`)
+	result, err := ParseSource(src, "test.go", "go", languages["go"])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ref := findRef(result.Refs, "Item")
+	if ref == nil {
+		debugParseResult(t, result)
+		t.Fatal("expected to find Item ref from slice composite literal")
+	}
+}
+
+func TestFeatureGoQualifiedCompositeLiteralRef(t *testing.T) {
+	src := []byte(`package main
+
+import "net/http"
+
+func main() {
+	_ = http.Client{Timeout: 30}
+}
+`)
+	result, err := ParseSource(src, "test.go", "go", languages["go"])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ref := findRef(result.Refs, "Client")
+	if ref == nil {
+		debugParseResult(t, result)
+		t.Fatal("expected to find Client ref from qualified composite literal")
+	}
+}
+
+// --- JS/TS New Expression Ref Tests ---
+
+func TestFeatureJSNewExpressionRef(t *testing.T) {
+	src := []byte(`class UsedClass {
+    constructor(name) {
+        this.name = name;
+    }
+}
+
+const obj = new UsedClass("test");
+`)
+	result, err := ParseSource(src, "test.js", "javascript", languages["javascript"])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ref := findRef(result.Refs, "UsedClass")
+	if ref == nil {
+		debugParseResult(t, result)
+		t.Fatal("expected to find UsedClass ref from new expression")
+	}
+	if ref.Line != 7 {
+		t.Errorf("expected UsedClass ref on line 7, got %d", ref.Line)
+	}
+}
+
+func TestFeatureTSNewExpressionRef(t *testing.T) {
+	src := []byte(`class Service {
+    private name: string;
+    constructor(name: string) {
+        this.name = name;
+    }
+}
+
+const svc = new Service("api");
+`)
+	result, err := ParseSource(src, "test.ts", "typescript", languages["typescript"])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ref := findRef(result.Refs, "Service")
+	if ref == nil {
+		debugParseResult(t, result)
+		t.Fatal("expected to find Service ref from new expression in TypeScript")
+	}
+	if ref.Line != 8 {
+		t.Errorf("expected Service ref on line 8, got %d", ref.Line)
+	}
+}
+
+func TestFeatureJSNewExpressionMemberRef(t *testing.T) {
+	src := []byte(`const ws = new WebSocket.Server({ port: 8080 });
+`)
+	result, err := ParseSource(src, "test.js", "javascript", languages["javascript"])
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ref := findRef(result.Refs, "Server")
+	if ref == nil {
+		debugParseResult(t, result)
+		t.Fatal("expected to find Server ref from new member expression")
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #13 — the parser was missing ref extraction for:

- **Go composite literals** — `UsedStruct{Name: "foo"}`, `map[MyKey]MyValue{}`, `[]Item{}`, and qualified types like `pkg.Struct{}` now emit `Ref` entries for their type identifiers
- **JS/TS `new` expressions** — `new UsedClass()` and `new pkg.Class()` now emit `Ref` entries for the constructor identifier

### Changes

- `parser/parser.go`: Added `extractRefGoCompositeLiteral()` handling `composite_literal` nodes (type_identifier, qualified_type, map_type, slice_type, array_type) and `extractRefNewExpr()` handling `new_expression` nodes. Updated `extractRef()` dispatch to route Go and JS/TS through the new extractors in addition to the existing `extractRefCallExpr`.
- `parser/parser_feature_test.go`: Added 7 feature tests covering struct literals, map literals, slice literals, qualified composite literals, JS new expressions, TS new expressions, and member new expressions.

## Test plan

- [x] All 7 new tests pass (`TestFeatureGoCompositeLiteralRef`, `TestFeatureGoMapLiteralRef`, `TestFeatureGoSliceLiteralRef`, `TestFeatureGoQualifiedCompositeLiteralRef`, `TestFeatureJSNewExpressionRef`, `TestFeatureTSNewExpressionRef`, `TestFeatureJSNewExpressionMemberRef`)
- [x] All existing parser tests continue to pass
- [x] All walker tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)