### PR TITLE
feat(dead): add dead symbol detection with confidence scoring

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to cymbal are documented here.
 
+## [Unreleased]
+
+### Added
+
+- **`cymbal dead` -- dead code detection with confidence ratings** -- finds symbols defined but never referenced in the codebase. Each result includes a confidence level (`high`, `medium`, `low`) with a human-readable reason explaining the classification. Language-aware heuristics: Go unexported symbols get `high` confidence, Python/Dart `_`-prefixed privates get `high`, methods get `low` (possible interface implementations), Ruby/Lua symbols get `low` (heavy metaprogramming). Entry points (`main`, `init`), test functions, constructors, getters, setters, and fields are excluded by default. Supports `--kind`, `--lang`, `--min-confidence`, `--include-tests`, `--limit`, and `--json` flags. Also available as `index.FindDeadSymbols()` library API (@Phototonic).
+
 ## [0.10.0] - 2026-04-15
 
 ### Highlights
@@ -57,6 +63,7 @@ All notable changes to cymbal are documented here.
 ### Docs
 
 - Updated README agent-integration guidance to reference `AGENTS.md` instead of `agent.md`.
+
 
 ## [0.9.2] - 2026-04-13
 

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ cymbal outline internal/auth/handler.go  # file structure
 cymbal refs handleAuth           # who calls this?
 cymbal importers internal/auth   # who imports this package?
 cymbal impact handleAuth         # what breaks if I change this?
-cymbal dead                      # find unreferenced symbols (potential dead code)
+cymbal dead                      # low-noise dead code candidates (use --kind for deeper audits)
 cymbal diff handleAuth main      # git diff scoped to a function
 cymbal context handleAuth        # bundled: source + types + callers + imports
 cymbal ls                        # file tree
@@ -130,13 +130,31 @@ The index auto-builds on first use — no manual `cymbal index .` required. Subs
 | `refs` | Find references / call sites. `--file` to scope by path |
 | `importers` | Reverse import lookup — who imports this? |
 | `impact` | Transitive callers — what's affected by a change? |
-| `dead` | Find potentially dead symbols — defined but never referenced |
+| `dead` | Find low-noise dead code candidates with confidence levels |
 | `diff` | Git diff scoped to a symbol's line range |
 | `context` | Bundled view: source + types + callers + imports |
 
 Commands that accept symbols support **batch**: `cymbal investigate Foo Bar Baz` runs all three in one invocation.
 
 All commands support `--json` for structured output.
+
+### Dead code confidence and filtering
+
+`cymbal dead` is conservative by default to reduce false positives for agents.
+
+- **Default mode** focuses on lower-noise symbol kinds.
+- **Use `--kind`** for targeted audits of noisier kinds.
+- **Use `--min-confidence`** to control strictness:
+  - `high` — strongest signal (best for automation)
+  - `medium` — balanced signal/noise for review
+  - `low` — broadest results, includes uncertain candidates
+
+By default, `dead` excludes high-noise kinds that are currently harder to validate reliably from refs alone (for example variables/constants and type-like symbols). You can still audit them explicitly:
+
+```sh
+cymbal dead --kind variable --min-confidence low
+cymbal dead --kind struct --min-confidence low
+```
 
 ## Agent integration
 
@@ -154,7 +172,7 @@ Use `cymbal` CLI for code navigation — prefer it over Read, Grep, Glob, or Bas
 - **To understand multiple symbols**: `cymbal investigate Foo Bar Baz` — batch mode, one invocation.
 - **To trace an execution path**: `cymbal trace <symbol>` — follows the call graph downward (what does X call, what do those call).
 - **To assess change risk**: `cymbal impact <symbol>` — follows the call graph upward (what breaks if X changes).
-- **To find dead code**: `cymbal dead` — symbols defined but never referenced, with confidence levels. Filter with `--kind`, `--lang`, `--min-confidence`.
+- **To find dead code**: `cymbal dead --min-confidence medium` — low-noise dead code candidates with confidence levels. Use `--kind` for targeted deep audits.
 - Before reading a file: `cymbal outline <file>` or `cymbal show <file:L1-L2>`
 - Before searching: `cymbal search <query>` (symbols) or `cymbal search <query> --text` (grep, delegates to rg when available)
 - To filter results: `cymbal search --path 'src/*' --exclude '*_test.go' <query>`
@@ -176,7 +194,7 @@ Run all cymbal commands as: `docker run --rm -v "$(pwd)":/workspace ghcr.io/1bro
 - **To understand multiple symbols**: `docker run --rm -v "$(pwd)":/workspace ghcr.io/1broseidon/cymbal investigate Foo Bar Baz` — batch mode, one invocation.
 - **To trace an execution path**: `docker run --rm -v "$(pwd)":/workspace ghcr.io/1broseidon/cymbal trace <symbol>` — follows the call graph downward (what does X call, what do those call).
 - **To assess change risk**: `docker run --rm -v "$(pwd)":/workspace ghcr.io/1broseidon/cymbal impact <symbol>` — follows the call graph upward (what breaks if X changes).
-- **To find dead code**: `docker run --rm -v "$(pwd)":/workspace ghcr.io/1broseidon/cymbal dead` — symbols defined but never referenced, with confidence levels. Filter with `--kind`, `--lang`, `--min-confidence`.
+- **To find dead code**: `docker run --rm -v "$(pwd)":/workspace ghcr.io/1broseidon/cymbal dead --min-confidence medium` — low-noise dead code candidates with confidence levels. Use `--kind` for targeted deep audits.
 - Before reading a file: `docker run --rm -v "$(pwd)":/workspace ghcr.io/1broseidon/cymbal outline <file>` or `docker run --rm -v "$(pwd)":/workspace ghcr.io/1broseidon/cymbal show <file:L1-L2>`
 - Before searching: `docker run --rm -v "$(pwd)":/workspace ghcr.io/1broseidon/cymbal search <query>` (symbols) or add `--text` for grep
 - Before exploring structure: `docker run --rm -v "$(pwd)":/workspace ghcr.io/1broseidon/cymbal ls` or `docker run --rm -v "$(pwd)":/workspace ghcr.io/1broseidon/cymbal ls --stats`

--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ cymbal outline internal/auth/handler.go  # file structure
 cymbal refs handleAuth           # who calls this?
 cymbal importers internal/auth   # who imports this package?
 cymbal impact handleAuth         # what breaks if I change this?
+cymbal dead                      # find unreferenced symbols (potential dead code)
 cymbal diff handleAuth main      # git diff scoped to a function
 cymbal context handleAuth        # bundled: source + types + callers + imports
 cymbal ls                        # file tree
@@ -129,6 +130,7 @@ The index auto-builds on first use — no manual `cymbal index .` required. Subs
 | `refs` | Find references / call sites. `--file` to scope by path |
 | `importers` | Reverse import lookup — who imports this? |
 | `impact` | Transitive callers — what's affected by a change? |
+| `dead` | Find potentially dead symbols — defined but never referenced |
 | `diff` | Git diff scoped to a symbol's line range |
 | `context` | Bundled view: source + types + callers + imports |
 
@@ -152,6 +154,7 @@ Use `cymbal` CLI for code navigation — prefer it over Read, Grep, Glob, or Bas
 - **To understand multiple symbols**: `cymbal investigate Foo Bar Baz` — batch mode, one invocation.
 - **To trace an execution path**: `cymbal trace <symbol>` — follows the call graph downward (what does X call, what do those call).
 - **To assess change risk**: `cymbal impact <symbol>` — follows the call graph upward (what breaks if X changes).
+- **To find dead code**: `cymbal dead` — symbols defined but never referenced, with confidence levels. Filter with `--kind`, `--lang`, `--min-confidence`.
 - Before reading a file: `cymbal outline <file>` or `cymbal show <file:L1-L2>`
 - Before searching: `cymbal search <query>` (symbols) or `cymbal search <query> --text` (grep, delegates to rg when available)
 - To filter results: `cymbal search --path 'src/*' --exclude '*_test.go' <query>`
@@ -173,6 +176,7 @@ Run all cymbal commands as: `docker run --rm -v "$(pwd)":/workspace ghcr.io/1bro
 - **To understand multiple symbols**: `docker run --rm -v "$(pwd)":/workspace ghcr.io/1broseidon/cymbal investigate Foo Bar Baz` — batch mode, one invocation.
 - **To trace an execution path**: `docker run --rm -v "$(pwd)":/workspace ghcr.io/1broseidon/cymbal trace <symbol>` — follows the call graph downward (what does X call, what do those call).
 - **To assess change risk**: `docker run --rm -v "$(pwd)":/workspace ghcr.io/1broseidon/cymbal impact <symbol>` — follows the call graph upward (what breaks if X changes).
+- **To find dead code**: `docker run --rm -v "$(pwd)":/workspace ghcr.io/1broseidon/cymbal dead` — symbols defined but never referenced, with confidence levels. Filter with `--kind`, `--lang`, `--min-confidence`.
 - Before reading a file: `docker run --rm -v "$(pwd)":/workspace ghcr.io/1broseidon/cymbal outline <file>` or `docker run --rm -v "$(pwd)":/workspace ghcr.io/1broseidon/cymbal show <file:L1-L2>`
 - Before searching: `docker run --rm -v "$(pwd)":/workspace ghcr.io/1broseidon/cymbal search <query>` (symbols) or add `--text` for grep
 - Before exploring structure: `docker run --rm -v "$(pwd)":/workspace ghcr.io/1broseidon/cymbal ls` or `docker run --rm -v "$(pwd)":/workspace ghcr.io/1broseidon/cymbal ls --stats`
@@ -191,6 +195,7 @@ An agent tracing an auth flow typically makes 15-20 sequential tool calls: show 
 | `investigate X` | "Tell me about X" | Adaptive (source + callers + impact or members) |
 | `trace X` | "What does X depend on?" | Downward (callees, depth 3) |
 | `impact X` | "What depends on X?" | Upward (callers, depth 2) |
+| `dead` | "What's unused?" | Unreferenced symbols with confidence |
 
 `investigate` replaces search → show → refs. `trace` replaces 10+ sequential show calls to follow a call chain. Together they reduce a 22-call investigation to 4 calls.
 
@@ -285,6 +290,7 @@ inv, _ := index.Investigate(dbPath, "handleAuth")
 trace, _ := index.FindTrace(dbPath, "handleAuth", 3, 50)
 impact, _ := index.FindImpact(dbPath, "handleAuth", 2, 100)
 refs, _ := index.FindReferences(dbPath, "handleAuth", 50)
+dead, _ := index.FindDeadSymbols(dbPath, index.DeadSymbolQuery{MinConfidence: "medium"})
 ```
 
 ```go

--- a/README.md
+++ b/README.md
@@ -142,18 +142,17 @@ All commands support `--json` for structured output.
 
 `cymbal dead` is conservative by default to reduce false positives for agents.
 
-- **Default mode** focuses on lower-noise symbol kinds.
-- **Use `--kind`** for targeted audits of noisier kinds.
+- **Default mode** excludes high-noise local/state symbols (variables/constants).
+- **Use `--kind`** for targeted audits when you want a specific symbol kind.
 - **Use `--min-confidence`** to control strictness:
   - `high` — strongest signal (best for automation)
   - `medium` — balanced signal/noise for review
   - `low` — broadest results, includes uncertain candidates
 
-By default, `dead` excludes high-noise kinds that are currently harder to validate reliably from refs alone (for example variables/constants and type-like symbols). You can still audit them explicitly:
+By default, `dead` excludes variables/constants because those refs are harder to validate reliably from call-site extraction alone. You can still audit them explicitly:
 
 ```sh
 cymbal dead --kind variable --min-confidence low
-cymbal dead --kind struct --min-confidence low
 ```
 
 ## Agent integration

--- a/cmd/dead.go
+++ b/cmd/dead.go
@@ -38,6 +38,7 @@ By default, test functions and entry points (main, init) are excluded.`,
 		limit, _ := cmd.Flags().GetInt("limit")
 		minConf, _ := cmd.Flags().GetString("min-confidence")
 		includeTests, _ := cmd.Flags().GetBool("include-tests")
+		minConf = strings.ToLower(strings.TrimSpace(minConf))
 
 		// Validate min-confidence flag.
 		switch minConf {
@@ -80,8 +81,8 @@ By default, test functions and entry points (main, init) are excluded.`,
 
 		var content strings.Builder
 		for _, r := range results {
-			fmt.Fprintf(&content, "  [%s]  %-10s  %-30s  %s:%d\n",
-				confTag(r.Confidence), r.Kind, r.Name, r.RelPath, r.StartLine)
+			fmt.Fprintf(&content, "  [%s]  %-10s  %-30s  %s:%d\n      reason: %s\n",
+				confTag(r.Confidence), r.Kind, r.Name, r.RelPath, r.StartLine, r.Reason)
 		}
 
 		meta := []kv{

--- a/cmd/dead.go
+++ b/cmd/dead.go
@@ -1,0 +1,130 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/1broseidon/cymbal/index"
+	"github.com/spf13/cobra"
+)
+
+var deadCmd = &cobra.Command{
+	Use:   "dead",
+	Short: "Find potentially dead symbols — defined but never referenced",
+	Long: `Find symbols that are defined in the codebase but have zero references.
+Each result includes a confidence level indicating how likely it is to be
+truly dead code:
+
+  high   — private/unexported symbol with no references (very likely dead)
+  medium — public or unknown-visibility symbol with no references
+  low    — method or symbol in a dynamic-dispatch language (may be false positive)
+
+Dead code detection is AST-level and name-based. Symbols may be falsely
+reported if they are:
+  - Called via reflection, decorators, or dynamic dispatch
+  - Part of a public API consumed by external packages
+  - Interface/protocol implementations invoked via polymorphism
+  - Used as callbacks, signal handlers, or framework hooks
+
+By default, test functions and entry points (main, init) are excluded.`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dbPath := getDBPath(cmd)
+		ensureFresh(dbPath)
+		jsonOut := getJSONFlag(cmd)
+
+		kind, _ := cmd.Flags().GetString("kind")
+		lang, _ := cmd.Flags().GetString("lang")
+		limit, _ := cmd.Flags().GetInt("limit")
+		minConf, _ := cmd.Flags().GetString("min-confidence")
+		includeTests, _ := cmd.Flags().GetBool("include-tests")
+
+		// Validate min-confidence flag.
+		switch minConf {
+		case "", "low", "medium", "high":
+			// valid
+		default:
+			return fmt.Errorf("invalid --min-confidence value %q: must be high, medium, or low", minConf)
+		}
+
+		q := index.DeadSymbolQuery{
+			Kind:          kind,
+			Language:      lang,
+			MinConfidence: minConf,
+			IncludeTests:  includeTests,
+			Limit:         limit,
+		}
+
+		results, err := index.FindDeadSymbols(dbPath, q)
+		if err != nil {
+			return err
+		}
+
+		if len(results) == 0 {
+			if jsonOut {
+				return writeJSON([]index.DeadSymbol{})
+			}
+			fmt.Println("No potentially dead symbols found.")
+			return nil
+		}
+
+		if jsonOut {
+			return writeJSON(results)
+		}
+
+		// Count by confidence.
+		counts := map[string]int{}
+		for _, r := range results {
+			counts[r.Confidence]++
+		}
+
+		var content strings.Builder
+		for _, r := range results {
+			fmt.Fprintf(&content, "  [%s]  %-10s  %-30s  %s:%d\n",
+				confTag(r.Confidence), r.Kind, r.Name, r.RelPath, r.StartLine)
+		}
+
+		meta := []kv{
+			{"total", fmt.Sprintf("%d", len(results))},
+		}
+		if counts["high"] > 0 {
+			meta = append(meta, kv{"high_confidence", fmt.Sprintf("%d", counts["high"])})
+		}
+		if counts["medium"] > 0 {
+			meta = append(meta, kv{"medium_confidence", fmt.Sprintf("%d", counts["medium"])})
+		}
+		if counts["low"] > 0 {
+			meta = append(meta, kv{"low_confidence", fmt.Sprintf("%d", counts["low"])})
+		}
+		if q.MinConfidence != "" && q.MinConfidence != "low" {
+			meta = append(meta, kv{"min_confidence", q.MinConfidence})
+		}
+		meta = append(meta, kv{"note", "AST-level detection — verify before deleting"})
+
+		frontmatter(meta, content.String())
+		return nil
+	},
+}
+
+func init() {
+	deadCmd.Flags().StringP("kind", "k", "", "filter by symbol kind (function, struct, method, ...)")
+	deadCmd.Flags().StringP("lang", "l", "", "filter by language (go, python, ...)")
+	deadCmd.Flags().IntP("limit", "n", 50, "max results")
+	deadCmd.Flags().String("min-confidence", "", "minimum confidence level: high, medium, low (default: show all)")
+	deadCmd.Flags().Bool("include-tests", false, "include test functions in results")
+	rootCmd.AddCommand(deadCmd)
+}
+
+// confTag returns a fixed-width confidence tag for aligned output.
+func confTag(confidence string) string {
+	switch confidence {
+	case "high":
+		return "HIGH  "
+	case "medium":
+		return "MEDIUM"
+	case "low":
+		return "LOW   "
+	default:
+		return "      "
+	}
+}

--- a/index/index.go
+++ b/index/index.go
@@ -900,6 +900,19 @@ func InvestigateResolved(dbPath string, sym SymbolResult) (*InvestigateResult, e
 	return res, nil
 }
 
+// FindDeadSymbols finds symbols with zero references (potential dead code).
+func FindDeadSymbols(dbPath string, q DeadSymbolQuery) ([]DeadSymbol, error) {
+	if q.Limit <= 0 {
+		q.Limit = 50
+	}
+	store, err := OpenStore(dbPath)
+	if err != nil {
+		return nil, err
+	}
+	defer store.Close()
+	return store.FindDeadSymbols(q)
+}
+
 // FindImpact performs transitive caller analysis for a symbol.
 func FindImpact(dbPath, symbolName string, depth, limit int) ([]ImpactResult, error) {
 	if limit <= 0 {

--- a/index/store.go
+++ b/index/store.go
@@ -1398,6 +1398,12 @@ func (s *Store) FindDeadSymbols(q DeadSymbolQuery) ([]DeadSymbol, error) {
 		q.Limit = 50
 	}
 
+	minConfidence, err := normalizeMinConfidence(q.MinConfidence)
+	if err != nil {
+		return nil, err
+	}
+	q.MinConfidence = minConfidence
+
 	// Build SQL query — fetch unreferenced symbols, excluding kinds that are
 	// inherently not useful to report (fields, constructors, etc.).
 	sqlQuery := `
@@ -1427,23 +1433,15 @@ func (s *Store) FindDeadSymbols(q DeadSymbolQuery) ([]DeadSymbol, error) {
 	}
 	defer rows.Close()
 
-	// Collect raw candidates — we'll apply Go-side filtering and confidence next.
-	var candidates []SymbolResult
+	// Stream candidates and apply post-processing filters/confidence incrementally
+	// to avoid holding all unreferenced symbols in memory for large repositories.
+	var results []DeadSymbol
 	for rows.Next() {
-		var r SymbolResult
-		if err := rows.Scan(&r.Name, &r.Kind, &r.File, &r.RelPath, &r.StartLine, &r.EndLine,
-			&r.Parent, &r.Depth, &r.Signature, &r.Language); err != nil {
+		var sym SymbolResult
+		if err := rows.Scan(&sym.Name, &sym.Kind, &sym.File, &sym.RelPath, &sym.StartLine, &sym.EndLine,
+			&sym.Parent, &sym.Depth, &sym.Signature, &sym.Language); err != nil {
 			return nil, err
 		}
-		candidates = append(candidates, r)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-
-	// Post-process: filter and assign confidence.
-	var results []DeadSymbol
-	for _, sym := range candidates {
 		// Always exclude: entry points.
 		if isEntryPoint(sym.Name, sym.Language) {
 			continue
@@ -1456,7 +1454,7 @@ func (s *Store) FindDeadSymbols(q DeadSymbolQuery) ([]DeadSymbol, error) {
 
 		// Always exclude: constructor-named methods that slip through the kind filter
 		// (JS/TS have kind="method" name="constructor"; Ruby has name="initialize").
-		if isConstructorName(sym.Name) {
+		if isConstructorSymbol(sym) {
 			continue
 		}
 
@@ -1465,7 +1463,7 @@ func (s *Store) FindDeadSymbols(q DeadSymbolQuery) ([]DeadSymbol, error) {
 			continue
 		}
 
-		confidence, reason := classifyDeadConfidence(sym.Name, sym.Kind, sym.Language, sym.RelPath, sym.Parent)
+		confidence, reason := classifyDeadConfidence(sym.Name, sym.Kind, sym.Language, sym.Parent)
 
 		// Filter by minimum confidence.
 		if !meetsMinConfidence(confidence, q.MinConfidence) {
@@ -1481,6 +1479,10 @@ func (s *Store) FindDeadSymbols(q DeadSymbolQuery) ([]DeadSymbol, error) {
 		if len(results) >= q.Limit {
 			break
 		}
+	}
+
+	if err := rows.Err(); err != nil {
+		return nil, err
 	}
 
 	return results, nil
@@ -1510,16 +1512,23 @@ func isDunderMethod(name string) bool {
 	return len(name) > 4 && strings.HasPrefix(name, "__") && strings.HasSuffix(name, "__")
 }
 
-// isConstructorName returns true for method names that are constructors by convention
-// in languages where the parser reports them as kind="method" rather than kind="constructor".
-func isConstructorName(name string) bool {
-	switch name {
-	case "constructor", // JS/TS class constructors
-		"initialize",  // Ruby constructors
-		"__construct": // PHP constructors
-		return true
+// isConstructorSymbol returns true for symbols that are constructors by
+// convention in languages where constructors may be emitted as kind="method".
+func isConstructorSymbol(sym SymbolResult) bool {
+	if sym.Kind != "method" {
+		return false
 	}
-	return false
+
+	switch sym.Language {
+	case "javascript", "typescript":
+		return sym.Name == "constructor"
+	case "ruby":
+		return sym.Name == "initialize"
+	case "php":
+		return sym.Name == "__construct"
+	default:
+		return false
+	}
 }
 
 // isTestSymbol detects test functions/methods by name and file path patterns.
@@ -1570,10 +1579,10 @@ func isTestSymbol(name, lang, relPath string) bool {
 //   - "high":   very likely truly dead — private/unexported, no refs, not a special method
 //   - "medium": probably dead — exported/public or visibility unknown, no refs
 //   - "low":    uncertain — methods (could implement interfaces), or dynamic-dispatch languages
-func classifyDeadConfidence(name, kind, language, relPath, parent string) (confidence, reason string) {
-	// A symbol is a method if its kind is "method" OR it has a parent
-	// (some parsers classify class methods as kind="function" with a non-empty parent).
-	isMethod := kind == "method" || parent != ""
+func classifyDeadConfidence(name, kind, language, parent string) (confidence, reason string) {
+	// Python parser can emit class methods as kind="function" with non-empty parent.
+	// Avoid treating all nested symbols in all languages as methods.
+	isMethod := kind == "method" || (language == "python" && parent != "")
 
 	switch language {
 	case "go":
@@ -1690,6 +1699,16 @@ func meetsMinConfidence(confidence, minConfidence string) bool {
 	}
 	rank := map[string]int{"low": 0, "medium": 1, "high": 2}
 	return rank[confidence] >= rank[minConfidence]
+}
+
+func normalizeMinConfidence(minConfidence string) (string, error) {
+	v := strings.ToLower(strings.TrimSpace(minConfidence))
+	switch v {
+	case "", "low", "medium", "high":
+		return v, nil
+	default:
+		return "", fmt.Errorf("invalid MinConfidence %q: must be high, medium, or low", minConfidence)
+	}
 }
 
 // FindImpact performs transitive caller analysis using BFS.

--- a/index/store.go
+++ b/index/store.go
@@ -1454,12 +1454,18 @@ func (s *Store) FindDeadSymbols(q DeadSymbolQuery) ([]DeadSymbol, error) {
 			continue
 		}
 
+		// Always exclude: constructor-named methods that slip through the kind filter
+		// (JS/TS have kind="method" name="constructor"; Ruby has name="initialize").
+		if isConstructorName(sym.Name) {
+			continue
+		}
+
 		// Exclude test functions by default.
 		if !q.IncludeTests && isTestSymbol(sym.Name, sym.Language, sym.RelPath) {
 			continue
 		}
 
-		confidence, reason := classifyDeadConfidence(sym.Name, sym.Kind, sym.Language, sym.RelPath)
+		confidence, reason := classifyDeadConfidence(sym.Name, sym.Kind, sym.Language, sym.RelPath, sym.Parent)
 
 		// Filter by minimum confidence.
 		if !meetsMinConfidence(confidence, q.MinConfidence) {
@@ -1504,6 +1510,18 @@ func isDunderMethod(name string) bool {
 	return len(name) > 4 && strings.HasPrefix(name, "__") && strings.HasSuffix(name, "__")
 }
 
+// isConstructorName returns true for method names that are constructors by convention
+// in languages where the parser reports them as kind="method" rather than kind="constructor".
+func isConstructorName(name string) bool {
+	switch name {
+	case "constructor", // JS/TS class constructors
+		"initialize",  // Ruby constructors
+		"__construct": // PHP constructors
+		return true
+	}
+	return false
+}
+
 // isTestSymbol detects test functions/methods by name and file path patterns.
 func isTestSymbol(name, lang, relPath string) bool {
 	// Language-specific name patterns.
@@ -1537,7 +1555,8 @@ func isTestSymbol(name, lang, relPath string) bool {
 		strings.Contains(relPathLower, "/tests/") || strings.Contains(relPathLower, "/test/") ||
 		strings.Contains(relPathLower, ".test.") || strings.Contains(relPathLower, ".spec.") ||
 		strings.Contains(relPathLower, "__tests__/") || strings.Contains(relPathLower, "\\test\\") ||
-		strings.Contains(relPathLower, "\\tests\\") || strings.Contains(relPathLower, "_test\\") {
+		strings.Contains(relPathLower, "\\tests\\") || strings.Contains(relPathLower, "_test\\") ||
+		strings.HasPrefix(relPathLower, "test_") || strings.Contains(relPathLower, "\\test_") {
 		return true
 	}
 
@@ -1551,8 +1570,10 @@ func isTestSymbol(name, lang, relPath string) bool {
 //   - "high":   very likely truly dead — private/unexported, no refs, not a special method
 //   - "medium": probably dead — exported/public or visibility unknown, no refs
 //   - "low":    uncertain — methods (could implement interfaces), or dynamic-dispatch languages
-func classifyDeadConfidence(name, kind, language, relPath string) (confidence, reason string) {
-	isMethod := kind == "method"
+func classifyDeadConfidence(name, kind, language, relPath, parent string) (confidence, reason string) {
+	// A symbol is a method if its kind is "method" OR it has a parent
+	// (some parsers classify class methods as kind="function" with a non-empty parent).
+	isMethod := kind == "method" || parent != ""
 
 	switch language {
 	case "go":

--- a/index/store.go
+++ b/index/store.go
@@ -1418,9 +1418,11 @@ func (s *Store) FindDeadSymbols(q DeadSymbolQuery) ([]DeadSymbol, error) {
 
 	// Refs are primarily call-site based. Variable/constant refs are not
 	// comprehensively tracked and create very noisy false positives by default.
-	// Users can still request them explicitly with --kind.
+	// Type-like symbols are also noisy because many parsers do not currently
+	// emit comprehensive type-usage refs. Users can still request these kinds
+	// explicitly with --kind.
 	if q.Kind == "" {
-		sqlQuery += " AND s.kind NOT IN ('variable','constant')"
+		sqlQuery += " AND s.kind NOT IN ('variable','constant','struct','class','interface','type','enum','object','trait','mixin','extension')"
 	}
 
 	if q.Kind != "" {
@@ -1597,6 +1599,9 @@ func classifyDeadConfidence(name, kind, language, parent string) (confidence, re
 	if kind == "variable" || kind == "constant" {
 		return "low", "variable/constant refs are not fully tracked by call-site extraction"
 	}
+	if isTypeLikeKind(kind) {
+		return "low", "type usage refs are not fully tracked; result may be false positive"
+	}
 
 	// Python parser can emit class methods as kind="function" with non-empty parent.
 	// Avoid treating all nested symbols in all languages as methods.
@@ -1726,6 +1731,15 @@ func normalizeMinConfidence(minConfidence string) (string, error) {
 		return v, nil
 	default:
 		return "", fmt.Errorf("invalid MinConfidence %q: must be high, medium, or low", minConfidence)
+	}
+}
+
+func isTypeLikeKind(kind string) bool {
+	switch kind {
+	case "struct", "class", "interface", "type", "enum", "object", "trait", "mixin", "extension":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/index/store.go
+++ b/index/store.go
@@ -1470,7 +1470,7 @@ func (s *Store) FindDeadSymbols(q DeadSymbolQuery) ([]DeadSymbol, error) {
 			continue
 		}
 
-		confidence, reason := classifyDeadConfidence(sym.Name, sym.Kind, sym.Language, sym.Parent)
+		confidence, reason := classifyDeadConfidence(sym.Name, sym.Kind, sym.Language, sym.Parent, sym.Depth)
 
 		// Filter by minimum confidence.
 		if !meetsMinConfidence(confidence, q.MinConfidence) {
@@ -1593,9 +1593,13 @@ func isTestSymbol(name, lang, relPath string) bool {
 //   - "high":   very likely truly dead — private/unexported, no refs, not a special method
 //   - "medium": probably dead — exported/public or visibility unknown, no refs
 //   - "low":    uncertain — methods (could implement interfaces), or dynamic-dispatch languages
-func classifyDeadConfidence(name, kind, language, parent string) (confidence, reason string) {
+func classifyDeadConfidence(name, kind, language, parent string, depth int) (confidence, reason string) {
 	if kind == "variable" || kind == "constant" {
 		return "low", "variable/constant refs are not fully tracked by call-site extraction"
+	}
+
+	if depth > 0 && isTypeLikeKind(kind) {
+		return "low", "nested type declaration — may be scope-local and harder to validate reliably"
 	}
 
 	// Python parser can emit class methods as kind="function" with non-empty parent.
@@ -1726,6 +1730,15 @@ func normalizeMinConfidence(minConfidence string) (string, error) {
 		return v, nil
 	default:
 		return "", fmt.Errorf("invalid MinConfidence %q: must be high, medium, or low", minConfidence)
+	}
+}
+
+func isTypeLikeKind(kind string) bool {
+	switch kind {
+	case "struct", "class", "interface", "type", "enum", "object", "trait", "mixin", "extension":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/index/store.go
+++ b/index/store.go
@@ -1374,6 +1374,303 @@ func (s *Store) FindTrace(symbolName string, depth, limit int) ([]TraceResult, e
 	return results, nil
 }
 
+// DeadSymbol holds a potentially dead symbol with confidence rating.
+type DeadSymbol struct {
+	SymbolResult
+	Confidence string `json:"confidence"` // "high", "medium", "low"
+	Reason     string `json:"reason"`     // explanation of why this confidence was assigned
+}
+
+// DeadSymbolQuery defines the options for dead symbol detection.
+type DeadSymbolQuery struct {
+	Kind          string // filter by symbol kind (e.g. "function", "struct")
+	Language      string // filter by language (e.g. "go", "python")
+	MinConfidence string // minimum confidence: "high", "medium", "low" (default "low" = all)
+	IncludeTests  bool   // include test functions (excluded by default)
+	Limit         int
+}
+
+// FindDeadSymbols finds symbols that have zero references in the codebase.
+// It queries for unreferenced symbols, filters out known false positives,
+// and assigns a confidence level to each result based on language-specific rules.
+func (s *Store) FindDeadSymbols(q DeadSymbolQuery) ([]DeadSymbol, error) {
+	if q.Limit <= 0 {
+		q.Limit = 50
+	}
+
+	// Build SQL query — fetch unreferenced symbols, excluding kinds that are
+	// inherently not useful to report (fields, constructors, etc.).
+	sqlQuery := `
+		SELECT s.name, s.kind, f.path, f.rel_path, s.start_line, s.end_line,
+		       s.parent, s.depth, s.signature, s.language
+		FROM symbols s
+		JOIN files f ON s.file_id = f.id
+		WHERE NOT EXISTS (SELECT 1 FROM refs r WHERE r.name = s.name)
+		  AND s.kind NOT IN ('constructor','getter','setter','impl','enum_member',
+		                     'field','module','namespace','resource','macro')`
+	var args []any
+
+	if q.Kind != "" {
+		sqlQuery += " AND s.kind = ?"
+		args = append(args, q.Kind)
+	}
+	if q.Language != "" {
+		sqlQuery += " AND s.language = ?"
+		args = append(args, q.Language)
+	}
+
+	sqlQuery += " ORDER BY f.rel_path, s.start_line"
+
+	rows, err := s.db.Query(sqlQuery, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	// Collect raw candidates — we'll apply Go-side filtering and confidence next.
+	var candidates []SymbolResult
+	for rows.Next() {
+		var r SymbolResult
+		if err := rows.Scan(&r.Name, &r.Kind, &r.File, &r.RelPath, &r.StartLine, &r.EndLine,
+			&r.Parent, &r.Depth, &r.Signature, &r.Language); err != nil {
+			return nil, err
+		}
+		candidates = append(candidates, r)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Post-process: filter and assign confidence.
+	var results []DeadSymbol
+	for _, sym := range candidates {
+		// Always exclude: entry points.
+		if isEntryPoint(sym.Name, sym.Language) {
+			continue
+		}
+
+		// Always exclude: Python dunder methods.
+		if sym.Language == "python" && isDunderMethod(sym.Name) {
+			continue
+		}
+
+		// Exclude test functions by default.
+		if !q.IncludeTests && isTestSymbol(sym.Name, sym.Language, sym.RelPath) {
+			continue
+		}
+
+		confidence, reason := classifyDeadConfidence(sym.Name, sym.Kind, sym.Language, sym.RelPath)
+
+		// Filter by minimum confidence.
+		if !meetsMinConfidence(confidence, q.MinConfidence) {
+			continue
+		}
+
+		results = append(results, DeadSymbol{
+			SymbolResult: sym,
+			Confidence:   confidence,
+			Reason:       reason,
+		})
+
+		if len(results) >= q.Limit {
+			break
+		}
+	}
+
+	return results, nil
+}
+
+// isEntryPoint returns true for known program entry points that should never
+// be reported as dead code regardless of reference count.
+func isEntryPoint(name, lang string) bool {
+	switch name {
+	case "main", "Main", "init", "Init":
+		return true
+	}
+	// Go: TestMain is a special entry point.
+	if lang == "go" && name == "TestMain" {
+		return true
+	}
+	// Python: __main__ module entry.
+	if lang == "python" && name == "__main__" {
+		return true
+	}
+	return false
+}
+
+// isDunderMethod returns true for Python double-underscore methods (__xxx__)
+// which are protocol methods called implicitly by the Python runtime.
+func isDunderMethod(name string) bool {
+	return len(name) > 4 && strings.HasPrefix(name, "__") && strings.HasSuffix(name, "__")
+}
+
+// isTestSymbol detects test functions/methods by name and file path patterns.
+func isTestSymbol(name, lang, relPath string) bool {
+	// Language-specific name patterns.
+	switch lang {
+	case "go":
+		// Go test functions: Test*, Benchmark*, Fuzz*, Example*
+		if strings.HasPrefix(name, "Test") || strings.HasPrefix(name, "Benchmark") ||
+			strings.HasPrefix(name, "Fuzz") || strings.HasPrefix(name, "Example") {
+			return true
+		}
+	case "python":
+		// Python: test_* functions, or classes named Test*
+		if strings.HasPrefix(name, "test_") || strings.HasPrefix(name, "Test") {
+			return true
+		}
+	case "ruby":
+		if strings.HasPrefix(name, "test_") {
+			return true
+		}
+	case "rust":
+		// Rust test functions are annotated with #[test], which we can't see
+		// from the name. But test modules are usually named "tests".
+		if name == "tests" {
+			return true
+		}
+	}
+
+	// File-path based detection (cross-language).
+	relPathLower := strings.ToLower(relPath)
+	if strings.Contains(relPathLower, "_test.") || strings.Contains(relPathLower, "/test_") ||
+		strings.Contains(relPathLower, "/tests/") || strings.Contains(relPathLower, "/test/") ||
+		strings.Contains(relPathLower, ".test.") || strings.Contains(relPathLower, ".spec.") ||
+		strings.Contains(relPathLower, "__tests__/") || strings.Contains(relPathLower, "\\test\\") ||
+		strings.Contains(relPathLower, "\\tests\\") || strings.Contains(relPathLower, "_test\\") {
+		return true
+	}
+
+	return false
+}
+
+// classifyDeadConfidence assigns a confidence level and reason to a dead symbol
+// based on language-specific visibility rules and symbol kind.
+//
+// Confidence levels:
+//   - "high":   very likely truly dead — private/unexported, no refs, not a special method
+//   - "medium": probably dead — exported/public or visibility unknown, no refs
+//   - "low":    uncertain — methods (could implement interfaces), or dynamic-dispatch languages
+func classifyDeadConfidence(name, kind, language, relPath string) (confidence, reason string) {
+	isMethod := kind == "method"
+
+	switch language {
+	case "go":
+		isExported := len(name) > 0 && name[0] >= 'A' && name[0] <= 'Z'
+		if isMethod {
+			if isExported {
+				return "low", "exported Go method — may satisfy an interface"
+			}
+			return "medium", "unexported Go method with no references"
+		}
+		if isExported {
+			return "medium", "exported Go symbol — may be used by external packages"
+		}
+		return "high", "unexported Go symbol with no references"
+
+	case "python":
+		if strings.HasPrefix(name, "_") {
+			// Single underscore = private convention.
+			if isMethod {
+				return "medium", "private Python method with no references"
+			}
+			return "high", "private Python symbol with no references"
+		}
+		if isMethod {
+			return "low", "Python method — may be called dynamically or satisfy a protocol"
+		}
+		return "medium", "Python symbol with no references"
+
+	case "ruby":
+		// Ruby has heavy metaprogramming — lower confidence across the board.
+		if isMethod {
+			return "low", "Ruby method — heavy use of metaprogramming and dynamic dispatch"
+		}
+		return "low", "Ruby symbol — may be called via metaprogramming"
+
+	case "lua":
+		return "low", "Lua symbol — dynamic dispatch common"
+
+	case "elixir":
+		if isMethod {
+			return "low", "Elixir function — may be called dynamically via apply/spawn"
+		}
+		return "medium", "Elixir symbol with no references"
+
+	case "javascript", "typescript":
+		if isMethod {
+			return "low", "JS/TS method — may be called dynamically or via prototype chain"
+		}
+		return "medium", "JS/TS symbol with no references"
+
+	case "java", "kotlin":
+		if isMethod {
+			return "low", "method — may implement an interface or be called via reflection"
+		}
+		return "medium", "symbol with no references — visibility cannot be determined from name"
+
+	case "csharp":
+		if isMethod {
+			return "low", "C# method — may implement an interface or be called via reflection"
+		}
+		return "medium", "C# symbol with no references — visibility cannot be determined from name"
+
+	case "swift":
+		if isMethod {
+			return "low", "Swift method — may satisfy a protocol requirement"
+		}
+		return "medium", "Swift symbol with no references"
+
+	case "dart":
+		if isMethod {
+			return "low", "Dart method — may implement an abstract class method"
+		}
+		// Dart private symbols start with _
+		if strings.HasPrefix(name, "_") {
+			return "high", "private Dart symbol with no references"
+		}
+		return "medium", "Dart symbol with no references"
+
+	case "c":
+		return "medium", "C symbol with no references — may be used via function pointers"
+
+	case "cpp":
+		if isMethod {
+			return "low", "C++ method — may implement a virtual interface"
+		}
+		return "medium", "C++ symbol with no references — may be used via function pointers"
+
+	case "rust":
+		if isMethod {
+			return "low", "Rust method — may implement a trait"
+		}
+		// Rust is private by default, but we can't verify pub status from the name.
+		return "medium", "Rust symbol with no references — private by default but pub status unknown"
+
+	case "php":
+		if isMethod {
+			return "low", "PHP method — may implement an interface or be called dynamically"
+		}
+		return "medium", "PHP symbol with no references"
+
+	default:
+		if isMethod {
+			return "low", "method with no references — may implement an interface"
+		}
+		return "medium", "symbol with no references"
+	}
+}
+
+// meetsMinConfidence checks whether a confidence level meets the minimum threshold.
+// Ordering: high > medium > low.
+func meetsMinConfidence(confidence, minConfidence string) bool {
+	if minConfidence == "" || minConfidence == "low" {
+		return true // show everything
+	}
+	rank := map[string]int{"low": 0, "medium": 1, "high": 2}
+	return rank[confidence] >= rank[minConfidence]
+}
+
 // FindImpact performs transitive caller analysis using BFS.
 func (s *Store) FindImpact(symbolName string, depth, limit int) ([]ImpactResult, error) {
 	if depth <= 0 {

--- a/index/store.go
+++ b/index/store.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+	"unicode"
+	"unicode/utf8"
 
 	_ "github.com/mattn/go-sqlite3"
 
@@ -71,6 +73,7 @@ CREATE INDEX IF NOT EXISTS idx_files_path ON files(path);
 CREATE INDEX IF NOT EXISTS idx_imports_raw ON imports(raw_path);
 CREATE INDEX IF NOT EXISTS idx_imports_file ON imports(file_id);
 CREATE INDEX IF NOT EXISTS idx_refs_name ON refs(name);
+CREATE INDEX IF NOT EXISTS idx_refs_name_lang ON refs(name, language);
 CREATE INDEX IF NOT EXISTS idx_refs_file ON refs(file_id);
 
 CREATE VIRTUAL TABLE IF NOT EXISTS symbols_fts USING fts5(
@@ -1398,6 +1401,11 @@ func (s *Store) FindDeadSymbols(q DeadSymbolQuery) ([]DeadSymbol, error) {
 		q.Limit = 50
 	}
 
+	q.Kind = strings.ToLower(strings.TrimSpace(q.Kind))
+	if q.Kind != "" && isAlwaysExcludedDeadKind(q.Kind) {
+		return nil, fmt.Errorf("kind %q is excluded from dead detection", q.Kind)
+	}
+
 	minConfidence, err := normalizeMinConfidence(q.MinConfidence)
 	if err != nil {
 		return nil, err
@@ -1608,7 +1616,7 @@ func classifyDeadConfidence(name, kind, language, parent string, depth int) (con
 
 	switch language {
 	case "go":
-		isExported := len(name) > 0 && name[0] >= 'A' && name[0] <= 'Z'
+		isExported := isGoExportedName(name)
 		if isMethod {
 			if isExported {
 				return "low", "exported Go method — may satisfy an interface"
@@ -1719,8 +1727,18 @@ func meetsMinConfidence(confidence, minConfidence string) bool {
 	if minConfidence == "" || minConfidence == "low" {
 		return true // show everything
 	}
-	rank := map[string]int{"low": 0, "medium": 1, "high": 2}
-	return rank[confidence] >= rank[minConfidence]
+	return confidenceRank(confidence) >= confidenceRank(minConfidence)
+}
+
+func confidenceRank(confidence string) int {
+	switch confidence {
+	case "high":
+		return 2
+	case "medium":
+		return 1
+	default:
+		return 0
+	}
 }
 
 func normalizeMinConfidence(minConfidence string) (string, error) {
@@ -1740,6 +1758,24 @@ func isTypeLikeKind(kind string) bool {
 	default:
 		return false
 	}
+}
+
+func isAlwaysExcludedDeadKind(kind string) bool {
+	switch kind {
+	case "constructor", "getter", "setter", "impl", "enum_member",
+		"field", "module", "namespace", "resource", "macro":
+		return true
+	default:
+		return false
+	}
+}
+
+func isGoExportedName(name string) bool {
+	if name == "" {
+		return false
+	}
+	r, _ := utf8.DecodeRuneInString(name)
+	return unicode.IsUpper(r)
 }
 
 // FindImpact performs transitive caller analysis using BFS.

--- a/index/store.go
+++ b/index/store.go
@@ -1418,11 +1418,9 @@ func (s *Store) FindDeadSymbols(q DeadSymbolQuery) ([]DeadSymbol, error) {
 
 	// Refs are primarily call-site based. Variable/constant refs are not
 	// comprehensively tracked and create very noisy false positives by default.
-	// Type-like symbols are also noisy because many parsers do not currently
-	// emit comprehensive type-usage refs. Users can still request these kinds
-	// explicitly with --kind.
+	// Users can still request these kinds explicitly with --kind.
 	if q.Kind == "" {
-		sqlQuery += " AND s.kind NOT IN ('variable','constant','struct','class','interface','type','enum','object','trait','mixin','extension')"
+		sqlQuery += " AND s.kind NOT IN ('variable','constant')"
 	}
 
 	if q.Kind != "" {
@@ -1599,9 +1597,6 @@ func classifyDeadConfidence(name, kind, language, parent string) (confidence, re
 	if kind == "variable" || kind == "constant" {
 		return "low", "variable/constant refs are not fully tracked by call-site extraction"
 	}
-	if isTypeLikeKind(kind) {
-		return "low", "type usage refs are not fully tracked; result may be false positive"
-	}
 
 	// Python parser can emit class methods as kind="function" with non-empty parent.
 	// Avoid treating all nested symbols in all languages as methods.
@@ -1731,15 +1726,6 @@ func normalizeMinConfidence(minConfidence string) (string, error) {
 		return v, nil
 	default:
 		return "", fmt.Errorf("invalid MinConfidence %q: must be high, medium, or low", minConfidence)
-	}
-}
-
-func isTypeLikeKind(kind string) bool {
-	switch kind {
-	case "struct", "class", "interface", "type", "enum", "object", "trait", "mixin", "extension":
-		return true
-	default:
-		return false
 	}
 }
 

--- a/index/store.go
+++ b/index/store.go
@@ -1411,10 +1411,17 @@ func (s *Store) FindDeadSymbols(q DeadSymbolQuery) ([]DeadSymbol, error) {
 		       s.parent, s.depth, s.signature, s.language
 		FROM symbols s
 		JOIN files f ON s.file_id = f.id
-		WHERE NOT EXISTS (SELECT 1 FROM refs r WHERE r.name = s.name)
+		WHERE NOT EXISTS (SELECT 1 FROM refs r WHERE r.name = s.name AND r.language = s.language)
 		  AND s.kind NOT IN ('constructor','getter','setter','impl','enum_member',
 		                     'field','module','namespace','resource','macro')`
 	var args []any
+
+	// Refs are primarily call-site based. Variable/constant refs are not
+	// comprehensively tracked and create very noisy false positives by default.
+	// Users can still request them explicitly with --kind.
+	if q.Kind == "" {
+		sqlQuery += " AND s.kind NOT IN ('variable','constant')"
+	}
 
 	if q.Kind != "" {
 		sqlQuery += " AND s.kind = ?"
@@ -1443,7 +1450,7 @@ func (s *Store) FindDeadSymbols(q DeadSymbolQuery) ([]DeadSymbol, error) {
 			return nil, err
 		}
 		// Always exclude: entry points.
-		if isEntryPoint(sym.Name, sym.Language) {
+		if isEntryPoint(sym.Name, sym.Kind, sym.Language) {
 			continue
 		}
 
@@ -1490,20 +1497,27 @@ func (s *Store) FindDeadSymbols(q DeadSymbolQuery) ([]DeadSymbol, error) {
 
 // isEntryPoint returns true for known program entry points that should never
 // be reported as dead code regardless of reference count.
-func isEntryPoint(name, lang string) bool {
-	switch name {
-	case "main", "Main", "init", "Init":
-		return true
+func isEntryPoint(name, kind, lang string) bool {
+	if kind != "function" && kind != "method" {
+		return false
 	}
-	// Go: TestMain is a special entry point.
-	if lang == "go" && name == "TestMain" {
-		return true
+
+	switch lang {
+	case "go":
+		// Go entry points.
+		return name == "main" || name == "init" || name == "TestMain"
+	case "c", "cpp":
+		// C/C++ executable entry point.
+		return name == "main"
+	case "java", "kotlin", "csharp":
+		// JVM/.NET entry method convention.
+		return name == "main" || name == "Main"
+	case "python":
+		// Python module entry guard (__name__ == "__main__").
+		return name == "__main__"
+	default:
+		return false
 	}
-	// Python: __main__ module entry.
-	if lang == "python" && name == "__main__" {
-		return true
-	}
-	return false
 }
 
 // isDunderMethod returns true for Python double-underscore methods (__xxx__)
@@ -1580,6 +1594,10 @@ func isTestSymbol(name, lang, relPath string) bool {
 //   - "medium": probably dead — exported/public or visibility unknown, no refs
 //   - "low":    uncertain — methods (could implement interfaces), or dynamic-dispatch languages
 func classifyDeadConfidence(name, kind, language, parent string) (confidence, reason string) {
+	if kind == "variable" || kind == "constant" {
+		return "low", "variable/constant refs are not fully tracked by call-site extraction"
+	}
+
 	// Python parser can emit class methods as kind="function" with non-empty parent.
 	// Avoid treating all nested symbols in all languages as methods.
 	isMethod := kind == "method" || (language == "python" && parent != "")
@@ -1622,7 +1640,7 @@ func classifyDeadConfidence(name, kind, language, parent string) (confidence, re
 		return "low", "Lua symbol — dynamic dispatch common"
 
 	case "elixir":
-		if isMethod {
+		if kind == "function" {
 			return "low", "Elixir function — may be called dynamically via apply/spawn"
 		}
 		return "medium", "Elixir symbol with no references"

--- a/index/store_feature_test.go
+++ b/index/store_feature_test.go
@@ -867,6 +867,134 @@ func TestFeatureStoreDeadSymbolsJSTestFileExclusion(t *testing.T) {
 	}
 }
 
+func TestFeatureStoreDeadSymbolsConstructorNameLanguageAware(t *testing.T) {
+	store, _ := newTestStore(t)
+	now := time.Now()
+
+	goFile, err := store.UpsertFile("/repo/main.go", "main.go", "go", "hash1", now, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.InsertSymbols(goFile, []symbols.Symbol{
+		{Name: "initialize", Kind: "function", File: "/repo/main.go", StartLine: 1, EndLine: 10, Language: "go"},
+		{Name: "constructor", Kind: "function", File: "/repo/main.go", StartLine: 12, EndLine: 20, Language: "go"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	jsFile, err := store.UpsertFile("/repo/app.js", "app.js", "javascript", "hash2", now, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.InsertSymbols(jsFile, []symbols.Symbol{
+		{Name: "constructor", Kind: "method", Parent: "Widget", File: "/repo/app.js", StartLine: 1, EndLine: 10, Language: "javascript"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	rubyFile, err := store.UpsertFile("/repo/app.rb", "app.rb", "ruby", "hash3", now, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.InsertSymbols(rubyFile, []symbols.Symbol{
+		{Name: "initialize", Kind: "method", Parent: "Widget", File: "/repo/app.rb", StartLine: 1, EndLine: 10, Language: "ruby"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := store.FindDeadSymbols(DeadSymbolQuery{Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	foundGoInitialize := false
+	foundGoConstructor := false
+	for _, r := range results {
+		switch {
+		case r.Language == "go" && r.Name == "initialize":
+			foundGoInitialize = true
+		case r.Language == "go" && r.Name == "constructor":
+			foundGoConstructor = true
+		case r.Language == "javascript" && r.Name == "constructor":
+			t.Error("JS method constructor should be excluded")
+		case r.Language == "ruby" && r.Name == "initialize":
+			t.Error("Ruby method initialize should be excluded")
+		}
+	}
+
+	if !foundGoInitialize {
+		t.Error("Go function named initialize should not be excluded")
+	}
+	if !foundGoConstructor {
+		t.Error("Go function named constructor should not be excluded")
+	}
+}
+
+func TestFeatureStoreDeadSymbolsParentNotAlwaysMethod(t *testing.T) {
+	store, _ := newTestStore(t)
+	now := time.Now()
+
+	fid, err := store.UpsertFile("/repo/main.go", "main.go", "go", "hash1", now, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.InsertSymbols(fid, []symbols.Symbol{
+		// Simulate a parser that emitted a nested function with parent metadata.
+		{Name: "nestedHelper", Kind: "function", Parent: "outerFunc", File: "/repo/main.go", StartLine: 1, EndLine: 10, Language: "go"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := store.FindDeadSymbols(DeadSymbolQuery{Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, r := range results {
+		if r.Name == "nestedHelper" {
+			if r.Confidence != "high" {
+				t.Fatalf("expected nested Go function to remain function-classified (high), got %q", r.Confidence)
+			}
+			return
+		}
+	}
+	t.Fatal("expected nestedHelper in dead symbols")
+}
+
+func TestFeatureStoreDeadSymbolsInvalidMinConfidence(t *testing.T) {
+	store, _ := newTestStore(t)
+
+	_, err := store.FindDeadSymbols(DeadSymbolQuery{MinConfidence: "bogus", Limit: 10})
+	if err == nil {
+		t.Fatal("expected error for invalid min confidence")
+	}
+}
+
+func TestFeatureStoreDeadSymbolsMinConfidenceNormalized(t *testing.T) {
+	store, _ := newTestStore(t)
+	now := time.Now()
+
+	fid, err := store.UpsertFile("/repo/main.go", "main.go", "go", "hash1", now, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.InsertSymbols(fid, []symbols.Symbol{
+		{Name: "helperFunc", Kind: "function", File: "/repo/main.go", StartLine: 1, EndLine: 10, Language: "go"},
+		{Name: "ExportedFunc", Kind: "function", File: "/repo/main.go", StartLine: 12, EndLine: 20, Language: "go"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := store.FindDeadSymbols(DeadSymbolQuery{MinConfidence: " HIGH ", Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(results) != 1 || results[0].Name != "helperFunc" {
+		t.Fatalf("expected only helperFunc with normalized HIGH filter, got %+v", results)
+	}
+}
+
 func TestFeatureStoreChildSymbolsFileScoped(t *testing.T) {
 	store, _ := newTestStore(t)
 	now := time.Now()

--- a/index/store_feature_test.go
+++ b/index/store_feature_test.go
@@ -825,6 +825,15 @@ func TestFeatureStoreDeadSymbolsExcludesFieldsAndConstructors(t *testing.T) {
 	}
 }
 
+func TestFeatureStoreDeadSymbolsExcludedKindReturnsError(t *testing.T) {
+	store, _ := newTestStore(t)
+
+	_, err := store.FindDeadSymbols(DeadSymbolQuery{Kind: "field", Limit: 10})
+	if err == nil {
+		t.Fatal("expected error for excluded dead-symbol kind")
+	}
+}
+
 func TestFeatureStoreDeadSymbolsDartPrivate(t *testing.T) {
 	store, _ := newTestStore(t)
 	now := time.Now()
@@ -1073,6 +1082,48 @@ func TestFeatureStoreDeadSymbolsVariableKindIsLowConfidence(t *testing.T) {
 	}
 	if results[0].Confidence != "low" {
 		t.Fatalf("expected low confidence for variable kind, got %q", results[0].Confidence)
+	}
+}
+
+func TestFeatureStoreDeadSymbolsGoUnicodeExportedName(t *testing.T) {
+	store, _ := newTestStore(t)
+	now := time.Now()
+
+	fid, err := store.UpsertFile("/repo/main.go", "main.go", "go", "hash1", now, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.InsertSymbols(fid, []symbols.Symbol{
+		{Name: "Éxported", Kind: "function", File: "/repo/main.go", StartLine: 1, EndLine: 10, Language: "go"},
+		{Name: "helper", Kind: "function", File: "/repo/main.go", StartLine: 12, EndLine: 20, Language: "go"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := store.FindDeadSymbols(DeadSymbolQuery{Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	seenUnicode := false
+	seenHelper := false
+	for _, r := range results {
+		if r.Name == "Éxported" {
+			seenUnicode = true
+			if r.Confidence != "medium" {
+				t.Fatalf("expected Unicode-exported Go function to be medium confidence, got %q", r.Confidence)
+			}
+		}
+		if r.Name == "helper" {
+			seenHelper = true
+			if r.Confidence != "high" {
+				t.Fatalf("expected unexported Go helper to be high confidence, got %q", r.Confidence)
+			}
+		}
+	}
+
+	if !seenUnicode || !seenHelper {
+		t.Fatalf("expected both symbols in results, got %+v", results)
 	}
 }
 

--- a/index/store_feature_test.go
+++ b/index/store_feature_test.go
@@ -1,6 +1,7 @@
 package index
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -322,6 +323,547 @@ func TestFeatureStoreImportsAndRefs(t *testing.T) {
 	}
 	if refs[0].Line != 10 {
 		t.Errorf("expected ref on line 10, got %d", refs[0].Line)
+	}
+}
+
+// ---------- Dead symbol detection tests ----------
+
+func TestFeatureStoreDeadSymbolsBasic(t *testing.T) {
+	store, _ := newTestStore(t)
+	now := time.Now()
+
+	// Insert a Go file with functions.
+	fid, err := store.UpsertFile("/repo/main.go", "main.go", "go", "hash1", now, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = store.InsertSymbols(fid, []symbols.Symbol{
+		{Name: "main", Kind: "function", File: "/repo/main.go", StartLine: 1, EndLine: 5, Language: "go"},
+		{Name: "helperFunc", Kind: "function", File: "/repo/main.go", StartLine: 7, EndLine: 15, Language: "go"},
+		{Name: "usedFunc", Kind: "function", File: "/repo/main.go", StartLine: 17, EndLine: 25, Language: "go"},
+		{Name: "ExportedUnused", Kind: "function", File: "/repo/main.go", StartLine: 27, EndLine: 35, Language: "go"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Add a ref for usedFunc — it should NOT appear as dead.
+	err = store.InsertRefs(fid, []symbols.Ref{
+		{Name: "usedFunc", Line: 3, Language: "go"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := store.FindDeadSymbols(DeadSymbolQuery{Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that "main" (entry point) is excluded.
+	for _, r := range results {
+		if r.Name == "main" {
+			t.Error("entry point 'main' should not be reported as dead")
+		}
+	}
+
+	// Check that "usedFunc" (has refs) is excluded.
+	for _, r := range results {
+		if r.Name == "usedFunc" {
+			t.Error("'usedFunc' has references and should not be reported as dead")
+		}
+	}
+
+	// Check that "helperFunc" (unexported, no refs) IS reported.
+	found := false
+	for _, r := range results {
+		if r.Name == "helperFunc" {
+			found = true
+			if r.Confidence != "high" {
+				t.Errorf("expected 'high' confidence for unexported Go function, got %q", r.Confidence)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'helperFunc' to be reported as dead")
+	}
+
+	// Check that "ExportedUnused" is reported with medium confidence.
+	found = false
+	for _, r := range results {
+		if r.Name == "ExportedUnused" {
+			found = true
+			if r.Confidence != "medium" {
+				t.Errorf("expected 'medium' confidence for exported Go function, got %q", r.Confidence)
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("expected 'ExportedUnused' to be reported as dead")
+	}
+}
+
+func TestFeatureStoreDeadSymbolsEntryPointExclusions(t *testing.T) {
+	store, _ := newTestStore(t)
+	now := time.Now()
+
+	fid, err := store.UpsertFile("/repo/main.go", "main.go", "go", "hash1", now, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = store.InsertSymbols(fid, []symbols.Symbol{
+		{Name: "main", Kind: "function", File: "/repo/main.go", StartLine: 1, EndLine: 5, Language: "go"},
+		{Name: "Main", Kind: "function", File: "/repo/main.go", StartLine: 7, EndLine: 10, Language: "go"},
+		{Name: "init", Kind: "function", File: "/repo/main.go", StartLine: 12, EndLine: 15, Language: "go"},
+		{Name: "Init", Kind: "function", File: "/repo/main.go", StartLine: 17, EndLine: 20, Language: "go"},
+		{Name: "TestMain", Kind: "function", File: "/repo/main.go", StartLine: 22, EndLine: 25, Language: "go"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := store.FindDeadSymbols(DeadSymbolQuery{Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, r := range results {
+		switch r.Name {
+		case "main", "Main", "init", "Init", "TestMain":
+			t.Errorf("entry point %q should be excluded from dead code results", r.Name)
+		}
+	}
+}
+
+func TestFeatureStoreDeadSymbolsTestFunctionExclusion(t *testing.T) {
+	store, _ := newTestStore(t)
+	now := time.Now()
+
+	fid, err := store.UpsertFile("/repo/calc_test.go", "calc_test.go", "go", "hash1", now, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = store.InsertSymbols(fid, []symbols.Symbol{
+		{Name: "TestAdd", Kind: "function", File: "/repo/calc_test.go", StartLine: 1, EndLine: 10, Language: "go"},
+		{Name: "BenchmarkAdd", Kind: "function", File: "/repo/calc_test.go", StartLine: 12, EndLine: 20, Language: "go"},
+		{Name: "helperInTest", Kind: "function", File: "/repo/calc_test.go", StartLine: 22, EndLine: 30, Language: "go"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Default: test functions excluded.
+	results, err := store.FindDeadSymbols(DeadSymbolQuery{Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range results {
+		if r.Name == "TestAdd" || r.Name == "BenchmarkAdd" {
+			t.Errorf("test function %q should be excluded by default", r.Name)
+		}
+	}
+	// helperInTest is in a _test.go file, so it should also be excluded.
+	for _, r := range results {
+		if r.Name == "helperInTest" {
+			t.Errorf("'helperInTest' in test file should be excluded by default")
+		}
+	}
+
+	// With IncludeTests: test functions included.
+	results, err = store.FindDeadSymbols(DeadSymbolQuery{IncludeTests: true, Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+	foundTest := false
+	for _, r := range results {
+		if r.Name == "TestAdd" {
+			foundTest = true
+			break
+		}
+	}
+	if !foundTest {
+		t.Error("expected 'TestAdd' to be included when IncludeTests=true")
+	}
+}
+
+func TestFeatureStoreDeadSymbolsPythonDunderExclusion(t *testing.T) {
+	store, _ := newTestStore(t)
+	now := time.Now()
+
+	fid, err := store.UpsertFile("/repo/app.py", "app.py", "python", "hash1", now, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = store.InsertSymbols(fid, []symbols.Symbol{
+		{Name: "__init__", Kind: "method", File: "/repo/app.py", StartLine: 1, EndLine: 5, Language: "python"},
+		{Name: "__str__", Kind: "method", File: "/repo/app.py", StartLine: 7, EndLine: 10, Language: "python"},
+		{Name: "_private_func", Kind: "function", File: "/repo/app.py", StartLine: 12, EndLine: 20, Language: "python"},
+		{Name: "public_func", Kind: "function", File: "/repo/app.py", StartLine: 22, EndLine: 30, Language: "python"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := store.FindDeadSymbols(DeadSymbolQuery{Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, r := range results {
+		if r.Name == "__init__" || r.Name == "__str__" {
+			t.Errorf("Python dunder method %q should be excluded", r.Name)
+		}
+	}
+
+	// _private_func should be reported with high confidence.
+	found := false
+	for _, r := range results {
+		if r.Name == "_private_func" {
+			found = true
+			if r.Confidence != "high" {
+				t.Errorf("expected 'high' confidence for private Python function, got %q", r.Confidence)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected '_private_func' to be reported as dead")
+	}
+
+	// public_func should be medium confidence.
+	found = false
+	for _, r := range results {
+		if r.Name == "public_func" {
+			found = true
+			if r.Confidence != "medium" {
+				t.Errorf("expected 'medium' confidence for public Python function, got %q", r.Confidence)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected 'public_func' to be reported as dead")
+	}
+}
+
+func TestFeatureStoreDeadSymbolsMethodConfidence(t *testing.T) {
+	store, _ := newTestStore(t)
+	now := time.Now()
+
+	fid, err := store.UpsertFile("/repo/handler.go", "handler.go", "go", "hash1", now, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = store.InsertSymbols(fid, []symbols.Symbol{
+		{Name: "ServeHTTP", Kind: "method", File: "/repo/handler.go", StartLine: 1, EndLine: 10, Parent: "Handler", Language: "go"},
+		{Name: "privateHelper", Kind: "method", File: "/repo/handler.go", StartLine: 12, EndLine: 20, Parent: "Handler", Language: "go"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := store.FindDeadSymbols(DeadSymbolQuery{Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, r := range results {
+		if r.Name == "ServeHTTP" && r.Confidence != "low" {
+			t.Errorf("exported Go method should have 'low' confidence, got %q", r.Confidence)
+		}
+		if r.Name == "privateHelper" && r.Confidence != "medium" {
+			t.Errorf("unexported Go method should have 'medium' confidence, got %q", r.Confidence)
+		}
+	}
+}
+
+func TestFeatureStoreDeadSymbolsKindFilter(t *testing.T) {
+	store, _ := newTestStore(t)
+	now := time.Now()
+
+	fid, err := store.UpsertFile("/repo/main.go", "main.go", "go", "hash1", now, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = store.InsertSymbols(fid, []symbols.Symbol{
+		{Name: "unusedFunc", Kind: "function", File: "/repo/main.go", StartLine: 1, EndLine: 10, Language: "go"},
+		{Name: "unusedStruct", Kind: "struct", File: "/repo/main.go", StartLine: 12, EndLine: 20, Language: "go"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Filter by kind=function — should only return functions.
+	results, err := store.FindDeadSymbols(DeadSymbolQuery{Kind: "function", Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range results {
+		if r.Kind != "function" {
+			t.Errorf("expected only functions when kind filter is set, got %q", r.Kind)
+		}
+	}
+	if len(results) == 0 {
+		t.Error("expected at least one dead function")
+	}
+}
+
+func TestFeatureStoreDeadSymbolsLanguageFilter(t *testing.T) {
+	store, _ := newTestStore(t)
+	now := time.Now()
+
+	fid1, err := store.UpsertFile("/repo/main.go", "main.go", "go", "hash1", now, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = store.InsertSymbols(fid1, []symbols.Symbol{
+		{Name: "goFunc", Kind: "function", File: "/repo/main.go", StartLine: 1, EndLine: 10, Language: "go"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	fid2, err := store.UpsertFile("/repo/app.py", "app.py", "python", "hash2", now, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = store.InsertSymbols(fid2, []symbols.Symbol{
+		{Name: "py_func", Kind: "function", File: "/repo/app.py", StartLine: 1, EndLine: 10, Language: "python"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Filter by language=go — should only return Go symbols.
+	results, err := store.FindDeadSymbols(DeadSymbolQuery{Language: "go", Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range results {
+		if r.Language != "go" {
+			t.Errorf("expected only Go symbols when language filter is set, got %q", r.Language)
+		}
+	}
+}
+
+func TestFeatureStoreDeadSymbolsMinConfidence(t *testing.T) {
+	store, _ := newTestStore(t)
+	now := time.Now()
+
+	fid, err := store.UpsertFile("/repo/main.go", "main.go", "go", "hash1", now, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = store.InsertSymbols(fid, []symbols.Symbol{
+		// unexported function → high confidence
+		{Name: "helperFunc", Kind: "function", File: "/repo/main.go", StartLine: 1, EndLine: 10, Language: "go"},
+		// exported function → medium confidence
+		{Name: "ExportedFunc", Kind: "function", File: "/repo/main.go", StartLine: 12, EndLine: 20, Language: "go"},
+		// exported method → low confidence
+		{Name: "ServeHTTP", Kind: "method", File: "/repo/main.go", StartLine: 22, EndLine: 30, Parent: "Handler", Language: "go"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// MinConfidence=high — should only return high confidence.
+	results, err := store.FindDeadSymbols(DeadSymbolQuery{MinConfidence: "high", Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range results {
+		if r.Confidence != "high" {
+			t.Errorf("with min-confidence=high, got result with confidence %q: %s", r.Confidence, r.Name)
+		}
+	}
+	if len(results) != 1 || results[0].Name != "helperFunc" {
+		t.Errorf("expected only 'helperFunc' with high confidence, got %d results", len(results))
+	}
+
+	// MinConfidence=medium — should return high and medium.
+	results, err = store.FindDeadSymbols(DeadSymbolQuery{MinConfidence: "medium", Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, r := range results {
+		if r.Confidence == "low" {
+			t.Errorf("with min-confidence=medium, should not include low confidence: %s", r.Name)
+		}
+	}
+
+	// MinConfidence=low (or empty) — should return all.
+	results, err = store.FindDeadSymbols(DeadSymbolQuery{MinConfidence: "low", Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 3 {
+		t.Errorf("expected 3 results with min-confidence=low, got %d", len(results))
+	}
+}
+
+func TestFeatureStoreDeadSymbolsLimit(t *testing.T) {
+	store, _ := newTestStore(t)
+	now := time.Now()
+
+	fid, err := store.UpsertFile("/repo/main.go", "main.go", "go", "hash1", now, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Insert 10 unreferenced symbols.
+	var syms []symbols.Symbol
+	for i := range 10 {
+		syms = append(syms, symbols.Symbol{
+			Name:      fmt.Sprintf("func%d", i),
+			Kind:      "function",
+			File:      "/repo/main.go",
+			StartLine: i*10 + 1,
+			EndLine:   i*10 + 8,
+			Language:  "go",
+		})
+	}
+	err = store.InsertSymbols(fid, syms)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Limit to 3.
+	results, err := store.FindDeadSymbols(DeadSymbolQuery{Limit: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) > 3 {
+		t.Errorf("expected at most 3 results, got %d", len(results))
+	}
+}
+
+func TestFeatureStoreDeadSymbolsExcludesFieldsAndConstructors(t *testing.T) {
+	store, _ := newTestStore(t)
+	now := time.Now()
+
+	fid, err := store.UpsertFile("/repo/model.go", "model.go", "go", "hash1", now, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = store.InsertSymbols(fid, []symbols.Symbol{
+		{Name: "New", Kind: "constructor", File: "/repo/model.go", StartLine: 1, EndLine: 5, Language: "go"},
+		{Name: "Name", Kind: "field", File: "/repo/model.go", StartLine: 7, EndLine: 7, Parent: "User", Language: "go"},
+		{Name: "Active", Kind: "getter", File: "/repo/model.go", StartLine: 9, EndLine: 12, Language: "go"},
+		{Name: "SetActive", Kind: "setter", File: "/repo/model.go", StartLine: 14, EndLine: 17, Language: "go"},
+		{Name: "ROLE_ADMIN", Kind: "enum_member", File: "/repo/model.go", StartLine: 19, EndLine: 19, Language: "go"},
+		{Name: "orphanFunc", Kind: "function", File: "/repo/model.go", StartLine: 21, EndLine: 30, Language: "go"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := store.FindDeadSymbols(DeadSymbolQuery{Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	excluded := map[string]bool{"New": true, "Name": true, "Active": true, "SetActive": true, "ROLE_ADMIN": true}
+	for _, r := range results {
+		if excluded[r.Name] {
+			t.Errorf("kind %q symbol %q should be excluded from dead code results", r.Kind, r.Name)
+		}
+	}
+
+	// orphanFunc should be reported.
+	found := false
+	for _, r := range results {
+		if r.Name == "orphanFunc" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected 'orphanFunc' to be reported as dead")
+	}
+}
+
+func TestFeatureStoreDeadSymbolsDartPrivate(t *testing.T) {
+	store, _ := newTestStore(t)
+	now := time.Now()
+
+	fid, err := store.UpsertFile("/repo/lib/widget.dart", "lib/widget.dart", "dart", "hash1", now, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = store.InsertSymbols(fid, []symbols.Symbol{
+		{Name: "_PrivateWidget", Kind: "class", File: "/repo/lib/widget.dart", StartLine: 1, EndLine: 20, Language: "dart"},
+		{Name: "PublicWidget", Kind: "class", File: "/repo/lib/widget.dart", StartLine: 22, EndLine: 40, Language: "dart"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := store.FindDeadSymbols(DeadSymbolQuery{Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, r := range results {
+		if r.Name == "_PrivateWidget" && r.Confidence != "high" {
+			t.Errorf("expected 'high' confidence for private Dart symbol, got %q", r.Confidence)
+		}
+		if r.Name == "PublicWidget" && r.Confidence != "medium" {
+			t.Errorf("expected 'medium' confidence for public Dart symbol, got %q", r.Confidence)
+		}
+	}
+}
+
+func TestFeatureStoreDeadSymbolsRubyLowConfidence(t *testing.T) {
+	store, _ := newTestStore(t)
+	now := time.Now()
+
+	fid, err := store.UpsertFile("/repo/app.rb", "app.rb", "ruby", "hash1", now, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = store.InsertSymbols(fid, []symbols.Symbol{
+		{Name: "unused_method", Kind: "function", File: "/repo/app.rb", StartLine: 1, EndLine: 10, Language: "ruby"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := store.FindDeadSymbols(DeadSymbolQuery{Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(results) == 0 {
+		t.Fatal("expected at least one result for Ruby")
+	}
+	if results[0].Confidence != "low" {
+		t.Errorf("expected 'low' confidence for Ruby symbol due to metaprogramming, got %q", results[0].Confidence)
+	}
+}
+
+func TestFeatureStoreDeadSymbolsJSTestFileExclusion(t *testing.T) {
+	store, _ := newTestStore(t)
+	now := time.Now()
+
+	// Symbols in a test file should be excluded by default.
+	fid, err := store.UpsertFile("/repo/src/utils.test.js", "src/utils.test.js", "javascript", "hash1", now, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = store.InsertSymbols(fid, []symbols.Symbol{
+		{Name: "testHelper", Kind: "function", File: "/repo/src/utils.test.js", StartLine: 1, EndLine: 10, Language: "javascript"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := store.FindDeadSymbols(DeadSymbolQuery{Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, r := range results {
+		if r.Name == "testHelper" {
+			t.Error("symbol in .test.js file should be excluded by default")
+		}
 	}
 }
 

--- a/index/store_feature_test.go
+++ b/index/store_feature_test.go
@@ -431,8 +431,53 @@ func TestFeatureStoreDeadSymbolsEntryPointExclusions(t *testing.T) {
 
 	for _, r := range results {
 		switch r.Name {
-		case "main", "Main", "init", "Init", "TestMain":
-			t.Errorf("entry point %q should be excluded from dead code results", r.Name)
+		case "main", "init", "TestMain":
+			t.Errorf("Go entry point %q should be excluded from dead code results", r.Name)
+		}
+	}
+
+	// Main/Init are not Go entry points and should remain candidates.
+	foundMain := false
+	foundInitCap := false
+	for _, r := range results {
+		if r.Name == "Main" {
+			foundMain = true
+		}
+		if r.Name == "Init" {
+			foundInitCap = true
+		}
+	}
+	if !foundMain {
+		t.Error("expected Go function Main to remain eligible")
+	}
+	if !foundInitCap {
+		t.Error("expected Go function Init to remain eligible")
+	}
+}
+
+func TestFeatureStoreDeadSymbolsEntryPointLanguageAware(t *testing.T) {
+	store, _ := newTestStore(t)
+	now := time.Now()
+
+	javaFile, err := store.UpsertFile("/repo/App.java", "App.java", "java", "hash1", now, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.InsertSymbols(javaFile, []symbols.Symbol{
+		{Name: "Main", Kind: "method", Parent: "App", File: "/repo/App.java", StartLine: 1, EndLine: 10, Language: "java"},
+		{Name: "helper", Kind: "method", Parent: "App", File: "/repo/App.java", StartLine: 12, EndLine: 20, Language: "java"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := store.FindDeadSymbols(DeadSymbolQuery{Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, r := range results {
+		if r.Language == "java" && r.Name == "Main" {
+			t.Fatal("expected Java Main entry method to be excluded")
 		}
 	}
 }
@@ -967,6 +1012,106 @@ func TestFeatureStoreDeadSymbolsInvalidMinConfidence(t *testing.T) {
 	_, err := store.FindDeadSymbols(DeadSymbolQuery{MinConfidence: "bogus", Limit: 10})
 	if err == nil {
 		t.Fatal("expected error for invalid min confidence")
+	}
+}
+
+func TestFeatureStoreDeadSymbolsDefaultExcludesVariablesAndConstants(t *testing.T) {
+	store, _ := newTestStore(t)
+	now := time.Now()
+
+	fid, err := store.UpsertFile("/repo/main.go", "main.go", "go", "hash1", now, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.InsertSymbols(fid, []symbols.Symbol{
+		{Name: "helper", Kind: "function", File: "/repo/main.go", StartLine: 1, EndLine: 10, Language: "go"},
+		{Name: "tmpVar", Kind: "variable", Parent: "helper", File: "/repo/main.go", StartLine: 3, EndLine: 3, Language: "go"},
+		{Name: "flag", Kind: "constant", File: "/repo/main.go", StartLine: 12, EndLine: 12, Language: "go"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := store.FindDeadSymbols(DeadSymbolQuery{Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	foundFunc := false
+	for _, r := range results {
+		if r.Kind == "variable" || r.Kind == "constant" {
+			t.Fatalf("did not expect %s in default dead-symbol results", r.Kind)
+		}
+		if r.Name == "helper" {
+			foundFunc = true
+		}
+	}
+	if !foundFunc {
+		t.Fatal("expected helper function in default dead-symbol results")
+	}
+}
+
+func TestFeatureStoreDeadSymbolsVariableKindIsLowConfidence(t *testing.T) {
+	store, _ := newTestStore(t)
+	now := time.Now()
+
+	fid, err := store.UpsertFile("/repo/main.go", "main.go", "go", "hash1", now, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.InsertSymbols(fid, []symbols.Symbol{
+		{Name: "tmpVar", Kind: "variable", Parent: "helper", File: "/repo/main.go", StartLine: 3, EndLine: 3, Language: "go"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := store.FindDeadSymbols(DeadSymbolQuery{Kind: "variable", Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 {
+		t.Fatalf("expected exactly one variable result, got %d", len(results))
+	}
+	if results[0].Confidence != "low" {
+		t.Fatalf("expected low confidence for variable kind, got %q", results[0].Confidence)
+	}
+}
+
+func TestFeatureStoreDeadSymbolsRefMatchLanguageScoped(t *testing.T) {
+	store, _ := newTestStore(t)
+	now := time.Now()
+
+	goFile, err := store.UpsertFile("/repo/main.go", "main.go", "go", "hash1", now, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.InsertSymbols(goFile, []symbols.Symbol{
+		{Name: "sharedName", Kind: "function", File: "/repo/main.go", StartLine: 1, EndLine: 10, Language: "go"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	jsFile, err := store.UpsertFile("/repo/app.js", "app.js", "javascript", "hash2", now, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.InsertRefs(jsFile, []symbols.Ref{{Name: "sharedName", Line: 1, Language: "javascript"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := store.FindDeadSymbols(DeadSymbolQuery{Language: "go", Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	found := false
+	for _, r := range results {
+		if r.Name == "sharedName" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected Go sharedName to remain dead; JS ref should not mark it alive")
 	}
 }
 

--- a/index/store_feature_test.go
+++ b/index/store_feature_test.go
@@ -1160,6 +1160,52 @@ func TestFeatureStoreDeadSymbolsTypeLikeKindsDefaultIncludedAfterRefFixes(t *tes
 	}
 }
 
+func TestFeatureStoreDeadSymbolsNestedTypeLikeIsLowConfidence(t *testing.T) {
+	store, _ := newTestStore(t)
+	now := time.Now()
+
+	fid, err := store.UpsertFile("/repo/main.go", "main.go", "go", "hash1", now, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.InsertSymbols(fid, []symbols.Symbol{
+		{Name: "LocalStruct", Kind: "struct", Parent: "helper", Depth: 1, File: "/repo/main.go", StartLine: 3, EndLine: 6, Language: "go"},
+		{Name: "TopStruct", Kind: "struct", File: "/repo/main.go", StartLine: 10, EndLine: 15, Language: "go"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := store.FindDeadSymbols(DeadSymbolQuery{Kind: "struct", Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(results) != 2 {
+		t.Fatalf("expected 2 struct results, got %d", len(results))
+	}
+
+	seenNested := false
+	seenTop := false
+	for _, r := range results {
+		switch r.Name {
+		case "LocalStruct":
+			seenNested = true
+			if r.Confidence != "low" {
+				t.Fatalf("expected nested type-like symbol low confidence, got %q", r.Confidence)
+			}
+		case "TopStruct":
+			seenTop = true
+			if r.Confidence != "medium" {
+				t.Fatalf("expected top-level exported Go struct medium confidence, got %q", r.Confidence)
+			}
+		}
+	}
+
+	if !seenNested || !seenTop {
+		t.Fatalf("expected both LocalStruct and TopStruct, got %+v", results)
+	}
+}
+
 func TestFeatureStoreDeadSymbolsMinConfidenceNormalized(t *testing.T) {
 	store, _ := newTestStore(t)
 	now := time.Now()

--- a/index/store_feature_test.go
+++ b/index/store_feature_test.go
@@ -1115,6 +1115,51 @@ func TestFeatureStoreDeadSymbolsRefMatchLanguageScoped(t *testing.T) {
 	}
 }
 
+func TestFeatureStoreDeadSymbolsTypeLikeKindsDefaultIncludedAfterRefFixes(t *testing.T) {
+	store, _ := newTestStore(t)
+	now := time.Now()
+
+	fid, err := store.UpsertFile("/repo/main.go", "main.go", "go", "hash1", now, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := store.InsertSymbols(fid, []symbols.Symbol{
+		{Name: "UnusedType", Kind: "struct", File: "/repo/main.go", StartLine: 1, EndLine: 5, Language: "go"},
+		{Name: "UsedType", Kind: "struct", File: "/repo/main.go", StartLine: 7, EndLine: 11, Language: "go"},
+		{Name: "callUsedType", Kind: "function", File: "/repo/main.go", StartLine: 13, EndLine: 20, Language: "go"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.InsertRefs(fid, []symbols.Ref{
+		{Name: "UsedType", Line: 14, Language: "go"},
+		{Name: "callUsedType", Line: 18, Language: "go"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := store.FindDeadSymbols(DeadSymbolQuery{Limit: 50})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	foundUnusedType := false
+	foundUsedType := false
+	for _, r := range results {
+		if r.Name == "UnusedType" {
+			foundUnusedType = true
+		}
+		if r.Name == "UsedType" {
+			foundUsedType = true
+		}
+	}
+	if !foundUnusedType {
+		t.Fatal("expected unreferenced type-like symbol to be included by default")
+	}
+	if foundUsedType {
+		t.Fatal("expected referenced type-like symbol to be excluded")
+	}
+}
+
 func TestFeatureStoreDeadSymbolsMinConfidenceNormalized(t *testing.T) {
 	store, _ := newTestStore(t)
 	now := time.Now()


### PR DESCRIPTION
## Summary

- Adds a new `cymbal dead` command to find symbols that are defined but have no references in the indexed repository.
- Implements a confidence model (`high`, `medium`, `low`) plus per-result reason text so agents can prioritize safer deletion candidates.
- Adds language-aware filtering and safety rules to reduce false positives:
  - entry point exclusions by language
  - constructor exclusions by language and kind
  - Python dunder exclusion
  - test symbol and test file exclusion by default
  - language-scoped ref matching (`name + language`) to avoid cross-language contamination
  - default exclusion of variable and constant kinds, with opt-in via `--kind`
  - nested type-like symbols downgraded to low confidence
- Adds store and public API support (`index.FindDeadSymbols`) and updates README and changelog.

## Testing

- Commands run:
  - `go test -tags "fts5" ./...`
  - `go test -race -tags "fts5" ./index`
  - `go test -tags "fts5" ./index -run DeadSymbols -count=1`
  - `go test -tags "fts5" ./parser -run "CompositeLiteral|NewExpression" -count=1`
  - `go vet -tags "fts5" ./...`
- Extra validation:
  - CLI smoke checks for dead command behavior:
    - `go run -tags "fts5" . dead --json`
    - `go run -tags "fts5" . dead --min-confidence medium --json`
    - `go run -tags "fts5" . dead --min-confidence high --json`
    - `go run -tags "fts5" . dead --kind variable --json`
  - Multi-language fixture checks and focused feature tests for constructor handling, test exclusion, language-scoped refs, confidence normalization, and nested type-like confidence downgrading.

## Checklist

- [x] I ran the required checks locally, or I explained why I could not in the Testing section.
- [x] I reviewed the diff for unrelated, generated, or vendored changes.
- [x] I updated docs, benchmarks, or release notes when behavior changed, or I explained why no updates were needed.
- [x] I filled out the Security Notes and Risks / Rollout sections below.

## Security Notes

- User input, file parsing, shell execution, or network behavior touched:
  - Query filtering and confidence logic for indexed symbol metadata in SQLite.
  - No new shell execution paths or network behavior added.
- New dependencies or vendored code added:
  - None.
- Secrets, credentials, or tokens touched:
  - None.
- Follow-up needed:
  - Continue refining confidence heuristics as parser coverage expands.

## Risks / Rollout

- Risk level:
  - Medium. This adds a new command and introduces heuristic classification, but defaults are conservative and heavily tested.
- Rollback plan:
  - Revert this PR commits to remove `dead` command, store/API additions, and related docs/tests.