### PR TITLE
feat(depends): add file-level import dependency graph command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to cymbal are documented here.
 
+## [Unreleased]
+
+### Added
+
+- **`cymbal depends`** -- new command that exports the file-level import dependency graph. Supports three output formats: Graphviz DOT (`--format dot`, default), Mermaid flowchart (`--format mermaid`), and JSON (`--format json`). Accepts `--scope <prefix>` to limit traversal to source files under that prefix (while still allowing dependencies that point outside it to appear in the graph) and `--depth <n>` to limit traversal hops from scoped files. Cycle detection is included in all formats.
+
 ## [0.10.0] - 2026-04-15
 
 ### Highlights
@@ -57,6 +63,7 @@ All notable changes to cymbal are documented here.
 ### Docs
 
 - Updated README agent-integration guidance to reference `AGENTS.md` instead of `agent.md`.
+
 
 ## [0.9.2] - 2026-04-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,6 @@ All notable changes to cymbal are documented here.
 
 - Updated README agent-integration guidance to reference `AGENTS.md` instead of `agent.md`.
 
-
 ## [0.9.2] - 2026-04-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ The index auto-builds on first use — no manual `cymbal index .` required. Subs
 | `refs` | Find references / call sites. `--file` to scope by path |
 | `importers` | Reverse import lookup — who imports this? |
 | `impact` | Transitive callers — what's affected by a change? |
+| `depends` | File-level import dependency graph (DOT / Mermaid / JSON) |
 | `diff` | Git diff scoped to a symbol's line range |
 | `context` | Bundled view: source + types + callers + imports |
 

--- a/cmd/depends.go
+++ b/cmd/depends.go
@@ -1,0 +1,150 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/1broseidon/cymbal/index"
+	"github.com/spf13/cobra"
+)
+
+var dependsCmd = &cobra.Command{
+	Use:   "depends",
+	Short: "Export the file-level import dependency graph",
+	Long: `Export the file-level import dependency graph for indexed files.
+
+Formats:
+  dot      Graphviz DOT language (default)
+  mermaid  Mermaid flowchart syntax
+  json     JSON with nodes, edges, and detected cycles
+
+Examples:
+  cymbal depends
+  cymbal depends --format mermaid
+  cymbal depends --format json
+  cymbal depends --scope cmd/
+  cymbal depends --scope internal/ --depth 2`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dbPath := getDBPath(cmd)
+		ensureFresh(dbPath)
+
+		format, _ := cmd.Flags().GetString("format")
+		scope, _ := cmd.Flags().GetString("scope")
+		depth, _ := cmd.Flags().GetInt("depth")
+
+		g, err := index.BuildDependsGraph(dbPath, index.DependsQuery{
+			Scope: scope,
+			Depth: depth,
+		})
+		if err != nil {
+			return err
+		}
+
+		if len(g.Nodes) == 0 {
+			return fmt.Errorf("no dependency edges found")
+		}
+
+		switch strings.ToLower(format) {
+		case "json":
+			return writeJSON(g)
+		case "mermaid":
+			printDependsMermaid(g)
+		default:
+			printDependsDOT(g)
+		}
+		return nil
+	},
+}
+
+func init() {
+	dependsCmd.Flags().StringP("format", "f", "dot", "output format: dot, mermaid, json")
+	dependsCmd.Flags().StringP("scope", "s", "", "restrict to files whose rel_path starts with this prefix")
+	dependsCmd.Flags().IntP("depth", "d", 0, "max traversal depth from scope roots (0 = unlimited)")
+	rootCmd.AddCommand(dependsCmd)
+}
+
+// sanitizeDOTID escapes a rel_path for use as a DOT node identifier.
+// Dots and slashes are replaced with underscores and the result is quoted.
+func sanitizeDOTID(relPath string) string {
+	id := strings.NewReplacer(
+		"/", "_",
+		"\\", "_",
+		".", "_",
+		"-", "_",
+	).Replace(relPath)
+	return `"` + id + `"`
+}
+
+// printDependsDOT writes the graph in Graphviz DOT format.
+func printDependsDOT(g *index.DependsGraph) {
+	fmt.Println("digraph depends {")
+	fmt.Println(`  rankdir=LR;`)
+	fmt.Println(`  node [shape=box fontname="Helvetica"];`)
+	fmt.Println()
+
+	for _, n := range g.Nodes {
+		label := n.ID
+		if n.Language != "" {
+			label = fmt.Sprintf("%s\\n[%s]", n.ID, n.Language)
+		}
+		fmt.Printf("  %s [label=%q];\n", sanitizeDOTID(n.ID), label)
+	}
+
+	if len(g.Nodes) > 0 && len(g.Edges) > 0 {
+		fmt.Println()
+	}
+
+	for _, e := range g.Edges {
+		fmt.Printf("  %s -> %s;\n", sanitizeDOTID(e.From), sanitizeDOTID(e.To))
+	}
+
+	if len(g.Cycles) > 0 {
+		fmt.Println()
+		fmt.Printf("  // %d cycle(s) detected:\n", len(g.Cycles))
+		for _, c := range g.Cycles {
+			fmt.Printf("  // %s\n", strings.Join(c, " -> "))
+		}
+	}
+
+	fmt.Println("}")
+}
+
+// sanitizeMermaidID returns a safe Mermaid node ID (alphanumeric + underscores).
+func sanitizeMermaidID(relPath string) string {
+	return strings.NewReplacer(
+		"/", "_",
+		"\\", "_",
+		".", "_",
+		"-", "_",
+	).Replace(relPath)
+}
+
+// printDependsMermaid writes the graph in Mermaid flowchart format.
+func printDependsMermaid(g *index.DependsGraph) {
+	fmt.Println("flowchart LR")
+
+	for _, n := range g.Nodes {
+		id := sanitizeMermaidID(n.ID)
+		label := n.ID
+		if n.Language != "" {
+			label = fmt.Sprintf("%s\n[%s]", n.ID, n.Language)
+		}
+		fmt.Printf("  %s[\"%s\"]\n", id, label)
+	}
+
+	if len(g.Nodes) > 0 && len(g.Edges) > 0 {
+		fmt.Println()
+	}
+
+	for _, e := range g.Edges {
+		fmt.Printf("  %s --> %s\n", sanitizeMermaidID(e.From), sanitizeMermaidID(e.To))
+	}
+
+	if len(g.Cycles) > 0 {
+		fmt.Println()
+		for _, c := range g.Cycles {
+			fmt.Printf("  %% cycle: %s\n", strings.Join(c, " -> "))
+		}
+	}
+}

--- a/cmd/depends.go
+++ b/cmd/depends.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 
 	"github.com/1broseidon/cymbal/index"
@@ -33,6 +34,13 @@ Examples:
 		scope, _ := cmd.Flags().GetString("scope")
 		depth, _ := cmd.Flags().GetInt("depth")
 
+		format = strings.ToLower(strings.TrimSpace(format))
+		switch format {
+		case "dot", "mermaid", "json":
+		default:
+			return fmt.Errorf("invalid format %q (expected: dot|mermaid|json)", format)
+		}
+
 		g, err := index.BuildDependsGraph(dbPath, index.DependsQuery{
 			Scope: scope,
 			Depth: depth,
@@ -45,12 +53,12 @@ Examples:
 			return fmt.Errorf("no dependency edges found")
 		}
 
-		switch strings.ToLower(format) {
+		switch format {
 		case "json":
 			return writeJSON(g)
 		case "mermaid":
 			printDependsMermaid(g)
-		default:
+		case "dot":
 			printDependsDOT(g)
 		}
 		return nil
@@ -64,20 +72,49 @@ func init() {
 	rootCmd.AddCommand(dependsCmd)
 }
 
-// sanitizeDOTID escapes a rel_path for use as a DOT node identifier.
-// Dots and slashes are replaced with underscores and the result is quoted.
-func sanitizeDOTID(relPath string) string {
-	id := strings.NewReplacer(
-		"/", "_",
-		"\\", "_",
-		".", "_",
-		"-", "_",
-	).Replace(relPath)
-	return `"` + id + `"`
+// dependsNodeIDs builds deterministic collision-free node IDs for graph outputs.
+// IDs are based on sorted node paths and use the n<index> form.
+func dependsNodeIDs(g *index.DependsGraph) map[string]string {
+	ids := make(map[string]string)
+	next := 0
+
+	for _, n := range g.Nodes {
+		if _, exists := ids[n.ID]; exists {
+			continue
+		}
+		ids[n.ID] = fmt.Sprintf("n%d", next)
+		next++
+	}
+
+	// Defensive fallback: include any edge endpoints missing from Nodes.
+	missingSet := make(map[string]struct{})
+	for _, e := range g.Edges {
+		if _, ok := ids[e.From]; !ok {
+			missingSet[e.From] = struct{}{}
+		}
+		if _, ok := ids[e.To]; !ok {
+			missingSet[e.To] = struct{}{}
+		}
+	}
+	if len(missingSet) > 0 {
+		missing := make([]string, 0, len(missingSet))
+		for m := range missingSet {
+			missing = append(missing, m)
+		}
+		sort.Strings(missing)
+		for _, m := range missing {
+			ids[m] = fmt.Sprintf("n%d", next)
+			next++
+		}
+	}
+
+	return ids
 }
 
 // printDependsDOT writes the graph in Graphviz DOT format.
 func printDependsDOT(g *index.DependsGraph) {
+	ids := dependsNodeIDs(g)
+
 	fmt.Println("digraph depends {")
 	fmt.Println(`  rankdir=LR;`)
 	fmt.Println(`  node [shape=box fontname="Helvetica"];`)
@@ -88,7 +125,7 @@ func printDependsDOT(g *index.DependsGraph) {
 		if n.Language != "" {
 			label = fmt.Sprintf("%s\\n[%s]", n.ID, n.Language)
 		}
-		fmt.Printf("  %s [label=%q];\n", sanitizeDOTID(n.ID), label)
+		fmt.Printf("  %s [label=%q];\n", ids[n.ID], label)
 	}
 
 	if len(g.Nodes) > 0 && len(g.Edges) > 0 {
@@ -96,7 +133,7 @@ func printDependsDOT(g *index.DependsGraph) {
 	}
 
 	for _, e := range g.Edges {
-		fmt.Printf("  %s -> %s;\n", sanitizeDOTID(e.From), sanitizeDOTID(e.To))
+		fmt.Printf("  %s -> %s;\n", ids[e.From], ids[e.To])
 	}
 
 	if len(g.Cycles) > 0 {
@@ -110,22 +147,14 @@ func printDependsDOT(g *index.DependsGraph) {
 	fmt.Println("}")
 }
 
-// sanitizeMermaidID returns a safe Mermaid node ID (alphanumeric + underscores).
-func sanitizeMermaidID(relPath string) string {
-	return strings.NewReplacer(
-		"/", "_",
-		"\\", "_",
-		".", "_",
-		"-", "_",
-	).Replace(relPath)
-}
-
 // printDependsMermaid writes the graph in Mermaid flowchart format.
 func printDependsMermaid(g *index.DependsGraph) {
+	ids := dependsNodeIDs(g)
+
 	fmt.Println("flowchart LR")
 
 	for _, n := range g.Nodes {
-		id := sanitizeMermaidID(n.ID)
+		id := ids[n.ID]
 		label := n.ID
 		if n.Language != "" {
 			label = fmt.Sprintf("%s\n[%s]", n.ID, n.Language)
@@ -138,7 +167,7 @@ func printDependsMermaid(g *index.DependsGraph) {
 	}
 
 	for _, e := range g.Edges {
-		fmt.Printf("  %s --> %s\n", sanitizeMermaidID(e.From), sanitizeMermaidID(e.To))
+		fmt.Printf("  %s --> %s\n", ids[e.From], ids[e.To])
 	}
 
 	if len(g.Cycles) > 0 {

--- a/cmd/depends.go
+++ b/cmd/depends.go
@@ -14,6 +14,9 @@ var dependsCmd = &cobra.Command{
 	Short: "Export the file-level import dependency graph",
 	Long: `Export the file-level import dependency graph for indexed files.
 
+Only files that participate in at least one resolved dependency edge are
+included in the rendered graph.
+
 Formats:
   dot      Graphviz DOT language (default)
   mermaid  Mermaid flowchart syntax
@@ -49,7 +52,7 @@ Examples:
 			return err
 		}
 
-		if len(g.Nodes) == 0 {
+		if len(g.Edges) == 0 {
 			return fmt.Errorf("no dependency edges found")
 		}
 
@@ -67,8 +70,8 @@ Examples:
 
 func init() {
 	dependsCmd.Flags().StringP("format", "f", "dot", "output format: dot, mermaid, json")
-	dependsCmd.Flags().StringP("scope", "s", "", "restrict to files whose rel_path starts with this prefix")
-	dependsCmd.Flags().IntP("depth", "d", 0, "max traversal depth from scope roots (0 = unlimited)")
+	dependsCmd.Flags().StringP("scope", "s", "", "restrict to dependency edges originating from files whose rel_path starts with this prefix")
+	dependsCmd.Flags().IntP("depth", "d", 0, "max traversal depth from scoped files (0 = unlimited)")
 	rootCmd.AddCommand(dependsCmd)
 }
 
@@ -157,8 +160,9 @@ func printDependsMermaid(g *index.DependsGraph) {
 		id := ids[n.ID]
 		label := n.ID
 		if n.Language != "" {
-			label = fmt.Sprintf("%s\n[%s]", n.ID, n.Language)
+			label = fmt.Sprintf("%s<br/>[%s]", n.ID, n.Language)
 		}
+		label = strings.ReplaceAll(label, `"`, `\"`)
 		fmt.Printf("  %s[\"%s\"]\n", id, label)
 	}
 

--- a/index/index.go
+++ b/index/index.go
@@ -963,3 +963,13 @@ func SymbolsByName(dbPath, name string) ([]SymbolResult, error) {
 	}
 	return store.SearchSymbols(name, "", "", true, 100)
 }
+
+// BuildDependsGraph constructs a file-level import dependency graph.
+func BuildDependsGraph(dbPath string, q DependsQuery) (*DependsGraph, error) {
+	store, err := OpenStore(dbPath)
+	if err != nil {
+		return nil, err
+	}
+	defer store.Close()
+	return store.BuildDependsGraph(q)
+}

--- a/index/store.go
+++ b/index/store.go
@@ -1523,39 +1523,27 @@ func (s *Store) BuildDependsGraph(q DependsQuery) (*DependsGraph, error) {
 		}
 	}
 
-	// Step 3: load all imports.
+	// Step 3: stream imports and resolve edges.
 	impRows, err := s.db.Query(`SELECT file_id, raw_path, language FROM imports`)
 	if err != nil {
 		return nil, err
 	}
-	type rawImp struct {
-		fileID  int64
-		rawPath string
-		lang    string
-	}
-	var imports []rawImp
+
+	type edgeKey struct{ from, to string }
+	edgeSet := make(map[edgeKey]struct{})
 	for impRows.Next() {
-		var ri rawImp
-		if err := impRows.Scan(&ri.fileID, &ri.rawPath, &ri.lang); err != nil {
+		var fileID int64
+		var rawPath, lang string
+		if err := impRows.Scan(&fileID, &rawPath, &lang); err != nil {
 			impRows.Close()
 			return nil, err
 		}
-		imports = append(imports, ri)
-	}
-	impRows.Close()
-	if err := impRows.Err(); err != nil {
-		return nil, err
-	}
 
-	// Step 4: resolve edges.
-	type edgeKey struct{ from, to string }
-	edgeSet := make(map[edgeKey]struct{})
-	for _, imp := range imports {
-		fromFile, ok := idToFile[imp.fileID]
+		fromFile, ok := idToFile[fileID]
 		if !ok {
 			continue
 		}
-		key := dependsImportKey(imp.rawPath, imp.lang)
+		key := dependsImportKey(rawPath, lang)
 		if key == "" {
 			continue
 		}
@@ -1566,6 +1554,10 @@ func (s *Store) BuildDependsGraph(q DependsQuery) (*DependsGraph, error) {
 			}
 			edgeSet[edgeKey{fromFile.relPath, toFile.relPath}] = struct{}{}
 		}
+	}
+	impRows.Close()
+	if err := impRows.Err(); err != nil {
+		return nil, err
 	}
 
 	// Step 5: apply scope filter.

--- a/index/store.go
+++ b/index/store.go
@@ -1438,3 +1438,434 @@ func (s *Store) FindImpact(symbolName string, depth, limit int) ([]ImpactResult,
 
 	return results, nil
 }
+
+// ---------------------------------------------------------------------------
+// Dependency graph
+// ---------------------------------------------------------------------------
+
+// DependsQuery holds parameters for BuildDependsGraph.
+type DependsQuery struct {
+	// Scope restricts the graph to files whose rel_path starts with this prefix.
+	// Empty means all files.
+	Scope string
+	// Depth limits traversal hops from the scope root files.
+	// 0 means unlimited.
+	Depth int
+}
+
+// DependsNode is a file node in the dependency graph.
+type DependsNode struct {
+	ID       string `json:"id"`
+	Language string `json:"language"`
+}
+
+// DependsEdge is a directed import edge between two files.
+type DependsEdge struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+// DependsGraph is the resolved file-level dependency graph.
+type DependsGraph struct {
+	Nodes  []DependsNode `json:"nodes"`
+	Edges  []DependsEdge `json:"edges"`
+	Cycles [][]string    `json:"cycles,omitempty"`
+}
+
+// BuildDependsGraph constructs a file-level import dependency graph.
+//
+// Edges are resolved by matching each import's raw_path last segment against
+// known file rel_paths (the same best-effort heuristic used by the importers
+// command). External / stdlib imports that do not match any indexed file
+// produce no edge.
+func (s *Store) BuildDependsGraph(q DependsQuery) (*DependsGraph, error) {
+	// Step 1: load all indexed files.
+	type fileRec struct {
+		id       int64
+		relPath  string
+		language string
+	}
+
+	var allFiles []fileRec
+	rows, err := s.db.Query(`SELECT id, rel_path, language FROM files ORDER BY rel_path`)
+	if err != nil {
+		return nil, err
+	}
+	for rows.Next() {
+		var f fileRec
+		if err := rows.Scan(&f.id, &f.relPath, &f.language); err != nil {
+			rows.Close()
+			return nil, err
+		}
+		allFiles = append(allFiles, f)
+	}
+	rows.Close()
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Build lookup maps.
+	idToFile := make(map[int64]*fileRec, len(allFiles))
+	pathToFile := make(map[string]*fileRec, len(allFiles))
+	for i := range allFiles {
+		idToFile[allFiles[i].id] = &allFiles[i]
+		pathToFile[allFiles[i].relPath] = &allFiles[i]
+	}
+
+	// Step 2: build segment -> files map for import resolution.
+	// Key is the last meaningful path component (no extension) of a rel_path.
+	segToFiles := make(map[string][]*fileRec)
+	for i := range allFiles {
+		f := &allFiles[i]
+		parts := dependsPathParts(f.relPath)
+		for _, seg := range parts {
+			segToFiles[seg] = append(segToFiles[seg], f)
+		}
+	}
+
+	// Step 3: load all imports.
+	impRows, err := s.db.Query(`SELECT file_id, raw_path FROM imports`)
+	if err != nil {
+		return nil, err
+	}
+	type rawImp struct {
+		fileID  int64
+		rawPath string
+	}
+	var imports []rawImp
+	for impRows.Next() {
+		var ri rawImp
+		if err := impRows.Scan(&ri.fileID, &ri.rawPath); err != nil {
+			impRows.Close()
+			return nil, err
+		}
+		imports = append(imports, ri)
+	}
+	impRows.Close()
+	if err := impRows.Err(); err != nil {
+		return nil, err
+	}
+
+	// Step 4: resolve edges.
+	type edgeKey struct{ from, to string }
+	edgeSet := make(map[edgeKey]struct{})
+	for _, imp := range imports {
+		fromFile, ok := idToFile[imp.fileID]
+		if !ok {
+			continue
+		}
+		key := dependsImportKey(imp.rawPath)
+		if key == "" {
+			continue
+		}
+		candidates := segToFiles[key]
+		for _, toFile := range candidates {
+			if toFile.relPath == fromFile.relPath {
+				continue // skip self-loops
+			}
+			edgeSet[edgeKey{fromFile.relPath, toFile.relPath}] = struct{}{}
+		}
+	}
+
+	// Step 5: apply scope filter.
+	var edges []DependsEdge
+	nodeSet := make(map[string]struct{})
+
+	if q.Scope != "" {
+		scope := filepath.ToSlash(q.Scope)
+		for ek := range edgeSet {
+			fromSlash := filepath.ToSlash(ek.from)
+			if strings.HasPrefix(fromSlash, scope) {
+				edges = append(edges, DependsEdge{From: ek.from, To: ek.to})
+				nodeSet[ek.from] = struct{}{}
+				nodeSet[ek.to] = struct{}{}
+			}
+		}
+	} else {
+		for ek := range edgeSet {
+			edges = append(edges, DependsEdge{From: ek.from, To: ek.to})
+			nodeSet[ek.from] = struct{}{}
+			nodeSet[ek.to] = struct{}{}
+		}
+	}
+
+	// Step 6: apply depth filter (BFS from scope roots).
+	if q.Depth > 0 {
+		// Determine root nodes: files within scope.
+		roots := make(map[string]struct{})
+		if q.Scope != "" {
+			scope := filepath.ToSlash(q.Scope)
+			for _, f := range allFiles {
+				if strings.HasPrefix(filepath.ToSlash(f.relPath), scope) {
+					roots[f.relPath] = struct{}{}
+				}
+			}
+		} else {
+			for n := range nodeSet {
+				roots[n] = struct{}{}
+			}
+		}
+
+		// Build adjacency from edges collected so far.
+		adj := make(map[string][]string)
+		for _, e := range edges {
+			adj[e.From] = append(adj[e.From], e.To)
+		}
+
+		// BFS to collect reachable nodes within depth.
+		visited := make(map[string]int) // node -> min depth reached
+		queue := make([]string, 0, len(roots))
+		for r := range roots {
+			visited[r] = 0
+			queue = append(queue, r)
+		}
+		for len(queue) > 0 {
+			cur := queue[0]
+			queue = queue[1:]
+			d := visited[cur]
+			if d >= q.Depth {
+				continue
+			}
+			for _, nb := range adj[cur] {
+				if _, seen := visited[nb]; !seen {
+					visited[nb] = d + 1
+					queue = append(queue, nb)
+				}
+			}
+		}
+
+		// Filter edges to only those where both endpoints are reachable.
+		var filteredEdges []DependsEdge
+		filteredNodes := make(map[string]struct{})
+		for _, e := range edges {
+			_, fromOK := visited[e.From]
+			_, toOK := visited[e.To]
+			if fromOK && toOK {
+				filteredEdges = append(filteredEdges, e)
+				filteredNodes[e.From] = struct{}{}
+				filteredNodes[e.To] = struct{}{}
+			}
+		}
+		edges = filteredEdges
+		nodeSet = filteredNodes
+	}
+
+	// Step 7: build sorted node list.
+	var nodes []DependsNode
+	for relPath := range nodeSet {
+		lang := ""
+		if f, ok := pathToFile[relPath]; ok {
+			lang = f.language
+		}
+		nodes = append(nodes, DependsNode{ID: relPath, Language: lang})
+	}
+	sort.Slice(nodes, func(i, j int) bool { return nodes[i].ID < nodes[j].ID })
+	sort.Slice(edges, func(i, j int) bool {
+		if edges[i].From != edges[j].From {
+			return edges[i].From < edges[j].From
+		}
+		return edges[i].To < edges[j].To
+	})
+
+	// Step 8: detect cycles.
+	cycles := dependsDetectCycles(edges)
+
+	return &DependsGraph{
+		Nodes:  nodes,
+		Edges:  edges,
+		Cycles: cycles,
+	}, nil
+}
+
+// dependsPathParts returns the lookup keys for a file rel_path used when
+// building the segment->files map. It returns both the bare file stem and
+// directory-qualified variants so that "utils/helpers.go" can be matched by
+// either "helpers" or "utils/helpers".
+func dependsPathParts(relPath string) []string {
+	slashed := filepath.ToSlash(relPath)
+	// Strip extension.
+	if dot := strings.LastIndex(slashed, "."); dot >= 0 {
+		slashed = slashed[:dot]
+	}
+	parts := strings.Split(slashed, "/")
+	if len(parts) == 0 {
+		return nil
+	}
+	// Always include the bare file stem.
+	keys := []string{parts[len(parts)-1]}
+	// Also add progressively longer suffix paths for disambiguation.
+	for i := len(parts) - 2; i >= 0; i-- {
+		keys = append(keys, strings.Join(parts[i:], "/"))
+	}
+	return keys
+}
+
+// dependsImportKey extracts the best single lookup key from a raw import path
+// as stored in the imports table. It handles language-specific prefixes and
+// relative paths.
+func dependsImportKey(rawPath string) string {
+	s := strings.TrimSpace(rawPath)
+	if s == "" {
+		return ""
+	}
+
+	// Python: "from pkg.mod import X" or "import pkg.mod"
+	if strings.HasPrefix(s, "from ") || strings.HasPrefix(s, "import ") {
+		fields := strings.Fields(s)
+		if len(fields) >= 2 {
+			mod := fields[1]
+			parts := strings.Split(mod, ".")
+			return parts[len(parts)-1]
+		}
+		return ""
+	}
+
+	// Rust: "use std::collections::HashMap;" or "use crate::foo::{Bar, Baz};"
+	if strings.HasPrefix(s, "use ") {
+		s = strings.TrimPrefix(s, "use ")
+		s = strings.TrimSuffix(s, ";")
+		// Drop brace groups.
+		if idx := strings.Index(s, "{"); idx >= 0 {
+			s = s[:idx]
+		}
+		s = strings.TrimRight(s, ":")
+		parts := strings.Split(s, "::")
+		last := strings.TrimSpace(parts[len(parts)-1])
+		if last == "" && len(parts) > 1 {
+			last = strings.TrimSpace(parts[len(parts)-2])
+		}
+		return last
+	}
+
+	// Java / Kotlin: "import com.example.Foo;" or "import static com.example.Foo;"
+	if strings.HasPrefix(s, "import ") {
+		s = strings.TrimPrefix(s, "import ")
+		s = strings.TrimPrefix(s, "static ")
+		s = strings.TrimSuffix(s, ";")
+		// Wildcard import -- not resolvable to a single file.
+		if strings.HasSuffix(s, ".*") {
+			return ""
+		}
+		parts := strings.Split(s, ".")
+		return parts[len(parts)-1]
+	}
+
+	// Relative paths: "./foo/bar" or "../baz/qux"
+	if strings.HasPrefix(s, "./") || strings.HasPrefix(s, "../") {
+		// Strip leading ./ and ../
+		for strings.HasPrefix(s, "./") || strings.HasPrefix(s, "../") {
+			if strings.HasPrefix(s, "./") {
+				s = s[2:]
+			} else {
+				s = s[3:]
+			}
+		}
+		// Take last slash component and strip extension.
+		if idx := strings.LastIndex(s, "/"); idx >= 0 {
+			s = s[idx+1:]
+		}
+		if dot := strings.LastIndex(s, "."); dot >= 0 {
+			s = s[:dot]
+		}
+		return s
+	}
+
+	// General: "github.com/user/repo/pkg" or "mylib/header.h"
+	// Normalise backslashes.
+	s = strings.ReplaceAll(s, "\\", "/")
+	if idx := strings.LastIndex(s, "/"); idx >= 0 {
+		s = s[idx+1:]
+	}
+	// Strip extension.
+	if dot := strings.LastIndex(s, "."); dot >= 0 {
+		s = s[:dot]
+	}
+	return s
+}
+
+// dependsDetectCycles runs a DFS on the edge list and returns all detected
+// cycles as normalised slices of rel_paths (rotated so smallest element is
+// first). Duplicate cycles are deduplicated.
+func dependsDetectCycles(edges []DependsEdge) [][]string {
+	// Build adjacency list.
+	adj := make(map[string][]string)
+	for _, e := range edges {
+		adj[e.From] = append(adj[e.From], e.To)
+	}
+
+	const (
+		white = 0
+		gray  = 1
+		black = 2
+	)
+	color := make(map[string]int)
+	var path []string
+	cycleSet := make(map[string][]string) // normalised key -> cycle
+
+	var dfs func(node string)
+	dfs = func(node string) {
+		color[node] = gray
+		path = append(path, node)
+		for _, nb := range adj[node] {
+			if color[nb] == gray {
+				// Found a back-edge: extract cycle from path.
+				start := -1
+				for i, n := range path {
+					if n == nb {
+						start = i
+						break
+					}
+				}
+				if start >= 0 {
+					cycle := make([]string, len(path)-start)
+					copy(cycle, path[start:])
+					// Normalise: rotate so smallest element is first.
+					minIdx := 0
+					for i, n := range cycle {
+						if n < cycle[minIdx] {
+							minIdx = i
+						}
+					}
+					norm := append(cycle[minIdx:], cycle[:minIdx]...)
+					key := strings.Join(norm, "|")
+					cycleSet[key] = norm
+				}
+			} else if color[nb] == white {
+				dfs(nb)
+			}
+		}
+		path = path[:len(path)-1]
+		color[node] = black
+	}
+
+	// Visit all nodes that appear in edges.
+	nodes := make(map[string]struct{})
+	for _, e := range edges {
+		nodes[e.From] = struct{}{}
+		nodes[e.To] = struct{}{}
+	}
+	sorted := make([]string, 0, len(nodes))
+	for n := range nodes {
+		sorted = append(sorted, n)
+	}
+	sort.Strings(sorted)
+	for _, n := range sorted {
+		if color[n] == white {
+			dfs(n)
+		}
+	}
+
+	if len(cycleSet) == 0 {
+		return nil
+	}
+	result := make([][]string, 0, len(cycleSet))
+	keys := make([]string, 0, len(cycleSet))
+	for k := range cycleSet {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		result = append(result, cycleSet[k])
+	}
+	return result
+}

--- a/index/store.go
+++ b/index/store.go
@@ -1524,18 +1524,19 @@ func (s *Store) BuildDependsGraph(q DependsQuery) (*DependsGraph, error) {
 	}
 
 	// Step 3: load all imports.
-	impRows, err := s.db.Query(`SELECT file_id, raw_path FROM imports`)
+	impRows, err := s.db.Query(`SELECT file_id, raw_path, language FROM imports`)
 	if err != nil {
 		return nil, err
 	}
 	type rawImp struct {
 		fileID  int64
 		rawPath string
+		lang    string
 	}
 	var imports []rawImp
 	for impRows.Next() {
 		var ri rawImp
-		if err := impRows.Scan(&ri.fileID, &ri.rawPath); err != nil {
+		if err := impRows.Scan(&ri.fileID, &ri.rawPath, &ri.lang); err != nil {
 			impRows.Close()
 			return nil, err
 		}
@@ -1554,7 +1555,7 @@ func (s *Store) BuildDependsGraph(q DependsQuery) (*DependsGraph, error) {
 		if !ok {
 			continue
 		}
-		key := dependsImportKey(imp.rawPath)
+		key := dependsImportKey(imp.rawPath, imp.lang)
 		if key == "" {
 			continue
 		}
@@ -1703,14 +1704,58 @@ func dependsPathParts(relPath string) []string {
 // dependsImportKey extracts the best single lookup key from a raw import path
 // as stored in the imports table. It handles language-specific prefixes and
 // relative paths.
-func dependsImportKey(rawPath string) string {
+func dependsImportKey(rawPath, language string) string {
 	s := strings.TrimSpace(rawPath)
 	if s == "" {
 		return ""
 	}
+	lang := strings.ToLower(strings.TrimSpace(language))
 
 	// Python: "from pkg.mod import X" or "import pkg.mod"
-	if strings.HasPrefix(s, "from ") || strings.HasPrefix(s, "import ") {
+	if lang == "python" {
+		fields := strings.Fields(s)
+		if len(fields) >= 2 {
+			mod := fields[1]
+			parts := strings.Split(mod, ".")
+			return parts[len(parts)-1]
+		}
+		return ""
+	}
+
+	// Java / Kotlin: "import com.example.Foo;" or "import static com.example.Foo;"
+	if lang == "java" || lang == "kotlin" {
+		s = strings.TrimPrefix(s, "import ")
+		s = strings.TrimPrefix(s, "static ")
+		s = strings.TrimSuffix(s, ";")
+		// Wildcard import -- not resolvable to a single file.
+		if strings.HasSuffix(s, ".*") {
+			return ""
+		}
+		parts := strings.Split(s, ".")
+		return parts[len(parts)-1]
+	}
+
+	// Fallback heuristics when language is missing or unknown.
+	if strings.HasPrefix(s, "from ") {
+		fields := strings.Fields(s)
+		if len(fields) >= 2 {
+			mod := fields[1]
+			parts := strings.Split(mod, ".")
+			return parts[len(parts)-1]
+		}
+		return ""
+	}
+	if strings.HasPrefix(s, "import static ") || (strings.HasPrefix(s, "import ") && strings.HasSuffix(s, ";")) {
+		s = strings.TrimPrefix(s, "import ")
+		s = strings.TrimPrefix(s, "static ")
+		s = strings.TrimSuffix(s, ";")
+		if strings.HasSuffix(s, ".*") {
+			return ""
+		}
+		parts := strings.Split(s, ".")
+		return parts[len(parts)-1]
+	}
+	if strings.HasPrefix(s, "import ") {
 		fields := strings.Fields(s)
 		if len(fields) >= 2 {
 			mod := fields[1]
@@ -1735,19 +1780,6 @@ func dependsImportKey(rawPath string) string {
 			last = strings.TrimSpace(parts[len(parts)-2])
 		}
 		return last
-	}
-
-	// Java / Kotlin: "import com.example.Foo;" or "import static com.example.Foo;"
-	if strings.HasPrefix(s, "import ") {
-		s = strings.TrimPrefix(s, "import ")
-		s = strings.TrimPrefix(s, "static ")
-		s = strings.TrimSuffix(s, ";")
-		// Wildcard import -- not resolvable to a single file.
-		if strings.HasSuffix(s, ".*") {
-			return ""
-		}
-		parts := strings.Split(s, ".")
-		return parts[len(parts)-1]
 	}
 
 	// Relative paths: "./foo/bar" or "../baz/qux"

--- a/index/store_feature_test.go
+++ b/index/store_feature_test.go
@@ -390,3 +390,246 @@ func TestFeatureStoreChildSymbolsFileScoped(t *testing.T) {
 		t.Errorf("Kotlin-scoped member: expected 'users', got %q", kt[0].Name)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// TestFeatureStoreDependsGraph
+// ---------------------------------------------------------------------------
+
+// insertDependsFixture sets up a small multi-file project:
+//
+//	main.go        imports config (go)
+//	config/config.go  imports util (go)
+//	util/util.go   (go, no indexed imports)
+//	app.py         imports util (python)
+//
+// Expected edges:
+//
+//	main.go -> config/config.go
+//	config/config.go -> util/util.go
+//	app.py -> util/util.go
+func insertDependsFixture(t *testing.T, store *Store) {
+	t.Helper()
+	now := time.Now()
+
+	fmain, err := store.UpsertFile("/repo/main.go", "main.go", "go", "h1", now, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fconf, err := store.UpsertFile("/repo/config/config.go", "config/config.go", "go", "h2", now, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	futil, err := store.UpsertFile("/repo/util/util.go", "util/util.go", "go", "h3", now, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fapp, err := store.UpsertFile("/repo/app.py", "app.py", "python", "h4", now, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// main.go imports "github.com/example/repo/config"
+	if err := store.InsertImports(fmain, []symbols.Import{
+		{RawPath: "github.com/example/repo/config", Language: "go"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// config/config.go imports "github.com/example/repo/util"
+	if err := store.InsertImports(fconf, []symbols.Import{
+		{RawPath: "github.com/example/repo/util", Language: "go"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	// util/util.go has no imports
+	_ = futil
+	// app.py imports "from util import helper"
+	if err := store.InsertImports(fapp, []symbols.Import{
+		{RawPath: "from util import helper", Language: "python"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// edgeExists returns true if the given from->to edge is present in g.Edges.
+func edgeExists(g *DependsGraph, from, to string) bool {
+	for _, e := range g.Edges {
+		if e.From == from && e.To == to {
+			return true
+		}
+	}
+	return false
+}
+
+// nodeExists returns true if a node with the given ID is present in g.Nodes.
+func nodeExists(g *DependsGraph, id string) bool {
+	for _, n := range g.Nodes {
+		if n.ID == id {
+			return true
+		}
+	}
+	return false
+}
+
+func TestFeatureStoreDependsGraph_BasicEdges(t *testing.T) {
+	store, _ := newTestStore(t)
+	insertDependsFixture(t, store)
+
+	g, err := store.BuildDependsGraph(DependsQuery{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should have at least 4 nodes.
+	if len(g.Nodes) < 4 {
+		t.Errorf("expected >= 4 nodes, got %d", len(g.Nodes))
+	}
+
+	// Expected edges.
+	wantEdges := [][2]string{
+		{"main.go", "config/config.go"},
+		{"config/config.go", "util/util.go"},
+		{"app.py", "util/util.go"},
+	}
+	for _, e := range wantEdges {
+		if !edgeExists(g, e[0], e[1]) {
+			t.Errorf("expected edge %s -> %s, not found in %v", e[0], e[1], g.Edges)
+		}
+	}
+}
+
+func TestFeatureStoreDependsGraph_NodeLanguage(t *testing.T) {
+	store, _ := newTestStore(t)
+	insertDependsFixture(t, store)
+
+	g, err := store.BuildDependsGraph(DependsQuery{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, n := range g.Nodes {
+		if n.Language == "" {
+			t.Errorf("node %q has empty language", n.ID)
+		}
+	}
+}
+
+func TestFeatureStoreDependsGraph_ScopeFilter(t *testing.T) {
+	store, _ := newTestStore(t)
+	insertDependsFixture(t, store)
+
+	// Scope to "config/" -- only edges where from starts with "config/"
+	g, err := store.BuildDependsGraph(DependsQuery{Scope: "config/"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, e := range g.Edges {
+		if !hasPrefix(e.From, "config/") {
+			t.Errorf("scope filter violated: edge from=%q should have prefix 'config/'", e.From)
+		}
+	}
+
+	if !edgeExists(g, "config/config.go", "util/util.go") {
+		t.Error("expected edge config/config.go -> util/util.go under scope 'config/'")
+	}
+	if edgeExists(g, "main.go", "config/config.go") {
+		t.Error("edge main.go -> config/config.go should not appear under scope 'config/'")
+	}
+}
+
+func TestFeatureStoreDependsGraph_NoSelfLoops(t *testing.T) {
+	store, _ := newTestStore(t)
+	now := time.Now()
+
+	fid, err := store.UpsertFile("/repo/self.go", "self.go", "go", "hs", now, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Import whose key matches self.go
+	if err := store.InsertImports(fid, []symbols.Import{
+		{RawPath: "github.com/x/self", Language: "go"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	g, err := store.BuildDependsGraph(DependsQuery{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range g.Edges {
+		if e.From == e.To {
+			t.Errorf("self-loop detected: %s -> %s", e.From, e.To)
+		}
+	}
+}
+
+func TestFeatureStoreDependsGraph_EmptyDB(t *testing.T) {
+	store, _ := newTestStore(t)
+
+	g, err := store.BuildDependsGraph(DependsQuery{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(g.Nodes) != 0 || len(g.Edges) != 0 {
+		t.Errorf("expected empty graph for empty DB, got %d nodes %d edges", len(g.Nodes), len(g.Edges))
+	}
+}
+
+func TestFeatureStoreDependsGraph_CycleDetection(t *testing.T) {
+	store, _ := newTestStore(t)
+	now := time.Now()
+
+	fa, err := store.UpsertFile("/repo/a.go", "a.go", "go", "ha", now, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+	fb, err := store.UpsertFile("/repo/b.go", "b.go", "go", "hb", now, 5)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// a.go imports b; b.go imports a -> cycle
+	if err := store.InsertImports(fa, []symbols.Import{{RawPath: "github.com/x/b", Language: "go"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.InsertImports(fb, []symbols.Import{{RawPath: "github.com/x/a", Language: "go"}}); err != nil {
+		t.Fatal(err)
+	}
+
+	g, err := store.BuildDependsGraph(DependsQuery{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(g.Cycles) == 0 {
+		t.Error("expected at least one cycle to be detected between a.go and b.go")
+	}
+}
+
+func TestFeatureStoreDependsGraph_SortedOutput(t *testing.T) {
+	store, _ := newTestStore(t)
+	insertDependsFixture(t, store)
+
+	g, err := store.BuildDependsGraph(DependsQuery{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 1; i < len(g.Nodes); i++ {
+		if g.Nodes[i].ID < g.Nodes[i-1].ID {
+			t.Errorf("nodes not sorted: %q before %q", g.Nodes[i-1].ID, g.Nodes[i].ID)
+		}
+	}
+	for i := 1; i < len(g.Edges); i++ {
+		prev := g.Edges[i-1]
+		cur := g.Edges[i]
+		if cur.From < prev.From || (cur.From == prev.From && cur.To < prev.To) {
+			t.Errorf("edges not sorted: (%s->%s) before (%s->%s)", prev.From, prev.To, cur.From, cur.To)
+		}
+	}
+}
+
+// hasPrefix is a helper to keep test code readable.
+func hasPrefix(s, prefix string) bool {
+	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}


### PR DESCRIPTION
## Summary

- Added `cymbal depends` command to export file-level import dependency graphs in DOT, Mermaid, and JSON formats.
- Added scope/depth filtering, cycle detection, language-aware import key parsing, collision-free graph node IDs, strict format validation, and streaming import-row processing.
- Updated README/CHANGELOG and added feature tests for graph construction behavior.

## Testing

- Commands run:
  - `go build -tags fts5 ./...`
  - `go test -tags fts5 ./...`
  - `go test -tags fts5 ./index/... -run TestFeatureStoreDependsGraph -v`
- Extra validation:
  - Verified all Copilot review threads were addressed with inline valid/invalid disposition comments and resolved.

## Checklist

- [x] I ran the required checks locally, or I explained why I could not in the Testing section.
- [x] I reviewed the diff for unrelated, generated, or vendored changes.
- [x] I updated docs, benchmarks, or release notes when behavior changed, or I explained why no updates were needed.
- [x] I filled out the Security Notes and Risks / Rollout sections below.

## Security Notes

- User input, file parsing, shell execution, or network behavior touched:
  - CLI user input handling touched for `--format`, `--scope`, and `--depth` in `cmd/depends.go`.
  - File parsing behavior unchanged.
  - No shell execution or network behavior changes in product code.
- New dependencies or vendored code added:
  - None.
- Secrets, credentials, or tokens touched:
  - None.
- Follow-up needed:
  - None required for this PR.

## Risks / Rollout

- Risk level:
  - Low to medium (new command and store query path; no schema migration).
- Rollback plan:
  - Revert commits on `feature/depends-graph` introducing `depends` command/store logic if regressions are observed.