### PR TITLE
feat(lang): unify language registry

### DIFF
--- a/index/index.go
+++ b/index/index.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/1broseidon/cymbal/lang"
 	"github.com/1broseidon/cymbal/parser"
 	"github.com/1broseidon/cymbal/symbols"
 	"github.com/1broseidon/cymbal/walker"
@@ -207,7 +208,7 @@ func Index(root, dbPath string, opts Options) (*Stats, error) {
 		return nil, fmt.Errorf("setting repo metadata: %w", err)
 	}
 
-	files, err := walker.Walk(root, workers, parser.SupportedLanguage)
+	files, err := walker.Walk(root, workers, lang.Default.Supported)
 	if err != nil {
 		return nil, fmt.Errorf("walking directory: %w", err)
 	}
@@ -256,7 +257,7 @@ func Index(root, dbPath string, opts Options) (*Stats, error) {
 		go func() {
 			defer parseWg.Done()
 			for f := range parseCh {
-				if !parser.SupportedLanguage(f.Language) {
+				if !lang.Default.Supported(f.Language) {
 					unsup.Add(1)
 					continue
 				}

--- a/lang/lang.go
+++ b/lang/lang.go
@@ -1,0 +1,139 @@
+// Package lang provides a unified language registry for cymbal.
+//
+// It is the single source of truth for language names, file extensions,
+// special filenames, and tree-sitter grammar availability. Both the
+// walker (file discovery) and parser (AST extraction) derive their
+// behavior from this registry.
+//
+// The registry intentionally models both:
+//   - recognized languages: files cymbal can classify by name/extension
+//   - supported languages: files cymbal can parse/index via tree-sitter
+//
+// Callers that need the parseable subset (for example indexing) should use
+// Registry.Supported or Language.Parseable instead of assuming every known
+// language can be parsed.
+package lang
+
+import (
+	"path/filepath"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+// Language defines a supported language and its properties.
+type Language struct {
+	// Name is the canonical language key (e.g. "go", "cpp").
+	Name string
+
+	// Extensions lists file extensions including the dot (e.g. ".go", ".cpp").
+	Extensions []string
+
+	// Filenames lists special filenames without extension (e.g. "Makefile").
+	Filenames []string
+
+	// TreeSitter is the tree-sitter grammar for this language.
+	// Nil means the language is recognized for file classification / CLI
+	// heuristics only and is not parseable for symbol indexing.
+	TreeSitter *sitter.Language
+}
+
+// Parseable returns true if this language has a tree-sitter grammar.
+func (l *Language) Parseable() bool {
+	return l.TreeSitter != nil
+}
+
+// Registry holds all known languages, indexed for fast lookup.
+type Registry struct {
+	langs  []*Language
+	byName map[string]*Language
+	byExt  map[string]*Language
+	byFile map[string]*Language
+}
+
+// NewRegistry builds a registry from the given language definitions.
+// It panics on duplicate names, extensions, or filenames.
+func NewRegistry(langs ...Language) *Registry {
+	r := &Registry{
+		byName: make(map[string]*Language, len(langs)),
+		byExt:  make(map[string]*Language, len(langs)*3),
+		byFile: make(map[string]*Language, 8),
+	}
+	for i := range langs {
+		l := &langs[i]
+		if _, dup := r.byName[l.Name]; dup {
+			panic("lang: duplicate language name: " + l.Name)
+		}
+		r.byName[l.Name] = l
+		r.langs = append(r.langs, l)
+
+		for _, ext := range l.Extensions {
+			if !strings.HasPrefix(ext, ".") {
+				panic("lang: extension must start with dot: " + ext)
+			}
+			if _, dup := r.byExt[ext]; dup {
+				panic("lang: duplicate extension: " + ext)
+			}
+			r.byExt[ext] = l
+		}
+		for _, fn := range l.Filenames {
+			if _, dup := r.byFile[fn]; dup {
+				panic("lang: duplicate filename: " + fn)
+			}
+			r.byFile[fn] = l
+		}
+	}
+	return r
+}
+
+// ForFile returns the language for a file path, or nil if unrecognized.
+// Extension matches take precedence over special-filename matches.
+func (r *Registry) ForFile(path string) *Language {
+	ext := filepath.Ext(path)
+	if l, ok := r.byExt[ext]; ok {
+		return l
+	}
+	base := filepath.Base(path)
+	if l, ok := r.byFile[base]; ok {
+		return l
+	}
+	return nil
+}
+
+// LangForFile returns the language name for a file path, or "" if unrecognized.
+// This is a convenience wrapper matching the old walker.LangForFile signature.
+func (r *Registry) LangForFile(path string) string {
+	if l := r.ForFile(path); l != nil {
+		return l.Name
+	}
+	return ""
+}
+
+// Supported returns true if the named language has a tree-sitter grammar.
+// Indexing and parsing code should use this to select the parseable subset
+// of known languages.
+func (r *Registry) Supported(name string) bool {
+	l, ok := r.byName[name]
+	return ok && l.TreeSitter != nil
+}
+
+// TreeSitter returns the tree-sitter grammar for the named language, or nil.
+func (r *Registry) TreeSitter(name string) *sitter.Language {
+	if l, ok := r.byName[name]; ok {
+		return l.TreeSitter
+	}
+	return nil
+}
+
+// Known returns true if the language name is in the registry (even without a parser).
+func (r *Registry) Known(name string) bool {
+	_, ok := r.byName[name]
+	return ok
+}
+
+// All returns all registered languages.
+func (r *Registry) All() []*Language {
+	out := make([]*Language, len(r.langs))
+	copy(out, r.langs)
+	return out
+}

--- a/lang/lang_test.go
+++ b/lang/lang_test.go
@@ -1,0 +1,243 @@
+package lang
+
+import (
+	"testing"
+)
+
+func TestDefaultRegistryNoPanic(t *testing.T) {
+	// Default is built at init time; if we get here it didn't panic.
+	if Default == nil {
+		t.Fatal("Default registry is nil")
+	}
+}
+
+func TestForFileExtensions(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		// Existing extensions
+		{"main.go", "go"},
+		{"app.py", "python"},
+		{"index.js", "javascript"},
+		{"App.jsx", "javascript"},
+		{"index.ts", "typescript"},
+		{"App.tsx", "typescript"},
+		{"lib.rs", "rust"},
+		{"app.rb", "ruby"},
+		{"Main.java", "java"},
+		{"foo.c", "c"},
+		{"foo.h", "c"},
+		{"foo.cpp", "cpp"},
+		{"foo.cc", "cpp"},
+		{"foo.hpp", "cpp"},
+		{"Account.cls", "apex"},
+		{"MyTrigger.trigger", "apex"},
+		{"Program.cs", "csharp"},
+		{"main.dart", "dart"},
+		{"App.swift", "swift"},
+		{"Main.kt", "kotlin"},
+		{"script.lua", "lua"},
+		{"index.php", "php"},
+		{"run.sh", "bash"},
+		{"run.bash", "bash"},
+		{"run.zsh", "bash"},
+		{"Main.scala", "scala"},
+		{"config.yaml", "yaml"},
+		{"config.yml", "yaml"},
+		{"mix.ex", "elixir"},
+		{"test.exs", "elixir"},
+		{"main.tf", "hcl"},
+		{"main.hcl", "hcl"},
+		{"schema.proto", "protobuf"},
+
+		// Issue #19 additions
+		{"foo.cxx", "cpp"},
+		{"foo.hxx", "cpp"},
+		{"foo.hh", "cpp"},
+		{"module.mjs", "javascript"},
+		{"module.cjs", "javascript"},
+		{"module.mts", "typescript"},
+		{"module.cts", "typescript"},
+		{"script.pyw", "python"},
+		{"build.kts", "kotlin"},
+		{"tasks.rake", "ruby"},
+		{"mygem.gemspec", "ruby"},
+		{"worksheet.sc", "scala"},
+		{"vars.tfvars", "hcl"},
+
+		// Recognition-only (no tree-sitter)
+		{"main.zig", "zig"},
+		{"config.toml", "toml"},
+		{"data.json", "json"},
+		{"README.md", "markdown"},
+		{"query.sql", "sql"},
+		{"module.erl", "erlang"},
+		{"Main.hs", "haskell"},
+		{"parser.ml", "ocaml"},
+		{"parser.mli", "ocaml"},
+		{"analysis.r", "r"},
+		{"analysis.R", "r"},
+		{"script.pl", "perl"},
+		{"script.pm", "perl"},
+		{"App.vue", "vue"},
+		{"App.svelte", "svelte"},
+		{"main.dart", "dart"},
+
+		// Unrecognized
+		{"foo.xyz", ""},
+		{"foo.txt", ""},
+		{"foo", ""},
+	}
+
+	for _, tt := range tests {
+		got := Default.LangForFile(tt.path)
+		if got != tt.want {
+			t.Errorf("LangForFile(%q) = %q, want %q", tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestForFileSpecialFilenames(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"Makefile", "make"},
+		{"makefile", "make"},
+		{"GNUmakefile", "make"},
+		{"Dockerfile", "dockerfile"},
+		{"Jenkinsfile", "groovy"},
+		{"CMakeLists.txt", "cmake"},
+		{"src/Makefile", "make"},
+		{"docker/Dockerfile", "dockerfile"},
+	}
+
+	for _, tt := range tests {
+		got := Default.LangForFile(tt.path)
+		if got != tt.want {
+			t.Errorf("LangForFile(%q) = %q, want %q", tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestSupported(t *testing.T) {
+	// Languages with tree-sitter grammars
+	for _, name := range []string{"go", "python", "javascript", "typescript", "rust", "ruby", "java", "c", "cpp", "apex", "csharp", "dart", "swift", "kotlin", "lua", "php", "bash", "scala", "yaml", "elixir", "hcl", "protobuf"} {
+		if !Default.Supported(name) {
+			t.Errorf("Supported(%q) = false, want true", name)
+		}
+	}
+
+	// Recognition-only languages should NOT be "supported" (no parser)
+	for _, name := range []string{"zig", "toml", "json", "markdown", "sql", "erlang", "haskell", "ocaml", "r", "perl", "vue", "svelte", "make", "dockerfile", "groovy", "cmake"} {
+		if Default.Supported(name) {
+			t.Errorf("Supported(%q) = true, want false (no tree-sitter grammar)", name)
+		}
+	}
+
+	// Unknown language
+	if Default.Supported("brainfuck") {
+		t.Error("Supported(brainfuck) = true, want false")
+	}
+}
+
+func TestTreeSitter(t *testing.T) {
+	if Default.TreeSitter("go") == nil {
+		t.Error("TreeSitter(go) = nil, want non-nil")
+	}
+	if Default.TreeSitter("make") != nil {
+		t.Error("TreeSitter(make) != nil, want nil")
+	}
+	if Default.TreeSitter("unknown") != nil {
+		t.Error("TreeSitter(unknown) != nil, want nil")
+	}
+}
+
+func TestKnown(t *testing.T) {
+	if !Default.Known("go") {
+		t.Error("Known(go) = false, want true")
+	}
+	if !Default.Known("make") {
+		t.Error("Known(make) = false, want true")
+	}
+	if Default.Known("brainfuck") {
+		t.Error("Known(brainfuck) = true, want false")
+	}
+}
+
+func TestAll(t *testing.T) {
+	all := Default.All()
+	if len(all) == 0 {
+		t.Fatal("All() returned empty")
+	}
+
+	// Verify it's a copy
+	all[0] = nil
+	if Default.All()[0] == nil {
+		t.Error("All() returned a reference to internal slice, not a copy")
+	}
+}
+
+func TestConsistency_ParseableLanguagesHaveTreeSitter(t *testing.T) {
+	for _, l := range Default.All() {
+		if l.Parseable() && l.TreeSitter == nil {
+			t.Errorf("language %q: Parseable() is true but TreeSitter is nil", l.Name)
+		}
+		if !l.Parseable() && l.TreeSitter != nil {
+			t.Errorf("language %q: Parseable() is false but TreeSitter is non-nil", l.Name)
+		}
+	}
+}
+
+func TestConsistency_AllExtensionsResolvable(t *testing.T) {
+	for _, l := range Default.All() {
+		for _, ext := range l.Extensions {
+			got := Default.ForFile("test" + ext)
+			if got != l {
+				t.Errorf("extension %q should resolve to %q, got %v", ext, l.Name, got)
+			}
+		}
+		for _, fn := range l.Filenames {
+			got := Default.ForFile(fn)
+			if got != l {
+				t.Errorf("filename %q should resolve to %q, got %v", fn, l.Name, got)
+			}
+		}
+	}
+}
+
+func TestDuplicateNamePanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for duplicate name")
+		}
+	}()
+	NewRegistry(
+		Language{Name: "go", Extensions: []string{".go"}},
+		Language{Name: "go", Extensions: []string{".go2"}},
+	)
+}
+
+func TestDuplicateExtensionPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for duplicate extension")
+		}
+	}()
+	NewRegistry(
+		Language{Name: "lang1", Extensions: []string{".x"}},
+		Language{Name: "lang2", Extensions: []string{".x"}},
+	)
+}
+
+func TestBadExtensionPanics(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic for extension without dot")
+		}
+	}()
+	NewRegistry(
+		Language{Name: "bad", Extensions: []string{"nodot"}},
+	)
+}

--- a/lang/lang_test.go
+++ b/lang/lang_test.go
@@ -82,7 +82,6 @@ func TestForFileExtensions(t *testing.T) {
 		{"script.pm", "perl"},
 		{"App.vue", "vue"},
 		{"App.svelte", "svelte"},
-		{"main.dart", "dart"},
 
 		// Unrecognized
 		{"foo.xyz", ""},

--- a/lang/registry.go
+++ b/lang/registry.go
@@ -1,0 +1,218 @@
+package lang
+
+import (
+	dart "github.com/UserNobody14/tree-sitter-dart/bindings/go"
+	apex "github.com/lynxbat/go-tree-sitter-apex"
+	sitter "github.com/smacker/go-tree-sitter"
+	"github.com/smacker/go-tree-sitter/bash"
+	"github.com/smacker/go-tree-sitter/c"
+	"github.com/smacker/go-tree-sitter/cpp"
+	"github.com/smacker/go-tree-sitter/csharp"
+	"github.com/smacker/go-tree-sitter/elixir"
+	"github.com/smacker/go-tree-sitter/golang"
+	"github.com/smacker/go-tree-sitter/hcl"
+	"github.com/smacker/go-tree-sitter/java"
+	"github.com/smacker/go-tree-sitter/javascript"
+	"github.com/smacker/go-tree-sitter/kotlin"
+	"github.com/smacker/go-tree-sitter/lua"
+	"github.com/smacker/go-tree-sitter/php"
+	"github.com/smacker/go-tree-sitter/protobuf"
+	"github.com/smacker/go-tree-sitter/python"
+	"github.com/smacker/go-tree-sitter/ruby"
+	"github.com/smacker/go-tree-sitter/rust"
+	"github.com/smacker/go-tree-sitter/scala"
+	"github.com/smacker/go-tree-sitter/swift"
+	"github.com/smacker/go-tree-sitter/typescript/typescript"
+	"github.com/smacker/go-tree-sitter/yaml"
+)
+
+// Default is the global language registry used throughout cymbal.
+// It is the single source of truth for language names, file extensions,
+// special filenames, and tree-sitter grammar availability.
+var Default = NewRegistry(
+	// ── Languages with tree-sitter grammars ──────────────────────────
+
+	Language{
+		Name:       "go",
+		Extensions: []string{".go"},
+		TreeSitter: golang.GetLanguage(),
+	},
+	Language{
+		Name:       "python",
+		Extensions: []string{".py", ".pyw"},
+		TreeSitter: python.GetLanguage(),
+	},
+	Language{
+		Name:       "javascript",
+		Extensions: []string{".js", ".jsx", ".mjs", ".cjs"},
+		TreeSitter: javascript.GetLanguage(),
+	},
+	Language{
+		Name:       "typescript",
+		Extensions: []string{".ts", ".tsx", ".mts", ".cts"},
+		TreeSitter: typescript.GetLanguage(),
+	},
+	Language{
+		Name:       "rust",
+		Extensions: []string{".rs"},
+		TreeSitter: rust.GetLanguage(),
+	},
+	Language{
+		Name:       "ruby",
+		Extensions: []string{".rb", ".rake", ".gemspec"},
+		TreeSitter: ruby.GetLanguage(),
+	},
+	Language{
+		Name:       "java",
+		Extensions: []string{".java"},
+		TreeSitter: java.GetLanguage(),
+	},
+	Language{
+		Name:       "c",
+		Extensions: []string{".c", ".h"},
+		TreeSitter: c.GetLanguage(),
+	},
+	Language{
+		Name:       "cpp",
+		Extensions: []string{".cpp", ".cc", ".hpp", ".cxx", ".hxx", ".hh"},
+		TreeSitter: cpp.GetLanguage(),
+	},
+	Language{
+		Name:       "apex",
+		Extensions: []string{".cls", ".trigger"},
+		TreeSitter: apex.GetLanguage(),
+	},
+	Language{
+		Name:       "csharp",
+		Extensions: []string{".cs"},
+		TreeSitter: csharp.GetLanguage(),
+	},
+	Language{
+		Name:       "dart",
+		Extensions: []string{".dart"},
+		TreeSitter: sitter.NewLanguage(dart.Language()),
+	},
+	Language{
+		Name:       "swift",
+		Extensions: []string{".swift"},
+		TreeSitter: swift.GetLanguage(),
+	},
+	Language{
+		Name:       "kotlin",
+		Extensions: []string{".kt", ".kts"},
+		TreeSitter: kotlin.GetLanguage(),
+	},
+	Language{
+		Name:       "lua",
+		Extensions: []string{".lua"},
+		TreeSitter: lua.GetLanguage(),
+	},
+	Language{
+		Name:       "php",
+		Extensions: []string{".php"},
+		TreeSitter: php.GetLanguage(),
+	},
+	Language{
+		Name:       "bash",
+		Extensions: []string{".sh", ".bash", ".zsh"},
+		TreeSitter: bash.GetLanguage(),
+	},
+	Language{
+		Name:       "scala",
+		Extensions: []string{".scala", ".sc"},
+		TreeSitter: scala.GetLanguage(),
+	},
+	Language{
+		Name:       "yaml",
+		Extensions: []string{".yaml", ".yml"},
+		TreeSitter: yaml.GetLanguage(),
+	},
+	Language{
+		Name:       "elixir",
+		Extensions: []string{".ex", ".exs"},
+		TreeSitter: elixir.GetLanguage(),
+	},
+	Language{
+		Name:       "hcl",
+		Extensions: []string{".tf", ".hcl", ".tfvars"},
+		TreeSitter: hcl.GetLanguage(),
+	},
+	Language{
+		Name:       "protobuf",
+		Extensions: []string{".proto"},
+		TreeSitter: protobuf.GetLanguage(),
+	},
+
+	// ── Recognition-only languages (no tree-sitter grammar) ─────────
+	// These are kept for file classification and non-indexing CLI flows.
+	// Indexing/parsing code should use lang.Default.Supported to select the
+	// parseable subset and must not assume every known language is indexable.
+
+	Language{
+		Name:       "zig",
+		Extensions: []string{".zig"},
+	},
+	Language{
+		Name:       "toml",
+		Extensions: []string{".toml"},
+	},
+	Language{
+		Name:       "json",
+		Extensions: []string{".json"},
+	},
+	Language{
+		Name:       "markdown",
+		Extensions: []string{".md"},
+	},
+	Language{
+		Name:       "sql",
+		Extensions: []string{".sql"},
+	},
+	Language{
+		Name:       "erlang",
+		Extensions: []string{".erl"},
+	},
+	Language{
+		Name:       "haskell",
+		Extensions: []string{".hs"},
+	},
+	Language{
+		Name:       "ocaml",
+		Extensions: []string{".ml", ".mli"},
+	},
+	Language{
+		Name:       "r",
+		Extensions: []string{".r", ".R"},
+	},
+	Language{
+		Name:       "perl",
+		Extensions: []string{".pl", ".pm"},
+	},
+	Language{
+		Name:       "vue",
+		Extensions: []string{".vue"},
+	},
+	Language{
+		Name:       "svelte",
+		Extensions: []string{".svelte"},
+	},
+
+	// ── Special-filename-only languages ─────────────────────────────
+
+	Language{
+		Name:      "make",
+		Filenames: []string{"Makefile", "makefile", "GNUmakefile"},
+	},
+	Language{
+		Name:      "dockerfile",
+		Filenames: []string{"Dockerfile"},
+	},
+	Language{
+		Name:      "groovy",
+		Filenames: []string{"Jenkinsfile"},
+	},
+	Language{
+		Name:      "cmake",
+		Filenames: []string{"CMakeLists.txt"},
+	},
+)

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -6,69 +6,23 @@ import (
 	"os"
 	"strings"
 
-	dart "github.com/UserNobody14/tree-sitter-dart/bindings/go"
-	apex "github.com/lynxbat/go-tree-sitter-apex"
 	sitter "github.com/smacker/go-tree-sitter"
-	"github.com/smacker/go-tree-sitter/bash"
-	"github.com/smacker/go-tree-sitter/c"
-	"github.com/smacker/go-tree-sitter/cpp"
-	"github.com/smacker/go-tree-sitter/csharp"
-	"github.com/smacker/go-tree-sitter/elixir"
-	"github.com/smacker/go-tree-sitter/golang"
-	"github.com/smacker/go-tree-sitter/hcl"
-	"github.com/smacker/go-tree-sitter/java"
-	"github.com/smacker/go-tree-sitter/javascript"
-	"github.com/smacker/go-tree-sitter/kotlin"
-	"github.com/smacker/go-tree-sitter/lua"
-	"github.com/smacker/go-tree-sitter/php"
-	"github.com/smacker/go-tree-sitter/protobuf"
-	"github.com/smacker/go-tree-sitter/python"
-	"github.com/smacker/go-tree-sitter/ruby"
-	"github.com/smacker/go-tree-sitter/rust"
-	"github.com/smacker/go-tree-sitter/scala"
-	"github.com/smacker/go-tree-sitter/swift"
-	"github.com/smacker/go-tree-sitter/typescript/typescript"
-	"github.com/smacker/go-tree-sitter/yaml"
 
+	"github.com/1broseidon/cymbal/lang"
 	"github.com/1broseidon/cymbal/symbols"
 )
 
-var languages = map[string]*sitter.Language{
-	"apex":       apex.GetLanguage(),
-	"go":         golang.GetLanguage(),
-	"python":     python.GetLanguage(),
-	"javascript": javascript.GetLanguage(),
-	"typescript": typescript.GetLanguage(),
-	"rust":       rust.GetLanguage(),
-	"ruby":       ruby.GetLanguage(),
-	"java":       java.GetLanguage(),
-	"c":          c.GetLanguage(),
-	"cpp":        cpp.GetLanguage(),
-	"csharp":     csharp.GetLanguage(),
-	"dart":       sitter.NewLanguage(dart.Language()),
-	"swift":      swift.GetLanguage(),
-	"kotlin":     kotlin.GetLanguage(),
-	"lua":        lua.GetLanguage(),
-	"php":        php.GetLanguage(),
-	"bash":       bash.GetLanguage(),
-	"scala":      scala.GetLanguage(),
-	"yaml":       yaml.GetLanguage(),
-	"elixir":     elixir.GetLanguage(),
-	"hcl":        hcl.GetLanguage(),
-	"protobuf":   protobuf.GetLanguage(),
-}
-
 // SupportedLanguage returns true if tree-sitter can parse this language.
-func SupportedLanguage(lang string) bool {
-	_, ok := languages[lang]
-	return ok
+// It delegates to the unified language registry.
+func SupportedLanguage(l string) bool {
+	return lang.Default.Supported(l)
 }
 
 // ParseFile parses a source file and extracts symbols, imports, and refs.
-func ParseFile(filePath, lang string) (*symbols.ParseResult, error) {
-	tsLang, ok := languages[lang]
-	if !ok {
-		return nil, fmt.Errorf("unsupported language: %s", lang)
+func ParseFile(filePath, l string) (*symbols.ParseResult, error) {
+	tsLang := lang.Default.TreeSitter(l)
+	if tsLang == nil {
+		return nil, fmt.Errorf("unsupported language: %s", l)
 	}
 
 	src, err := os.ReadFile(filePath)
@@ -76,17 +30,17 @@ func ParseFile(filePath, lang string) (*symbols.ParseResult, error) {
 		return nil, fmt.Errorf("reading file: %w", err)
 	}
 
-	return ParseSource(src, filePath, lang, tsLang)
+	return ParseSource(src, filePath, l, tsLang)
 }
 
 // ParseBytes parses source bytes (already read) and extracts symbols, imports, and refs.
 // Use this when you already have the file contents to avoid a redundant ReadFile.
-func ParseBytes(src []byte, filePath, lang string) (*symbols.ParseResult, error) {
-	tsLang, ok := languages[lang]
-	if !ok {
-		return nil, fmt.Errorf("unsupported language: %s", lang)
+func ParseBytes(src []byte, filePath, l string) (*symbols.ParseResult, error) {
+	tsLang := lang.Default.TreeSitter(l)
+	if tsLang == nil {
+		return nil, fmt.Errorf("unsupported language: %s", l)
 	}
-	return ParseSource(src, filePath, lang, tsLang)
+	return ParseSource(src, filePath, l, tsLang)
 }
 
 // ParseSource parses source bytes and extracts symbols, imports, and refs.

--- a/parser/parser_feature_test.go
+++ b/parser/parser_feature_test.go
@@ -3,6 +3,7 @@ package parser
 import (
 	"testing"
 
+	"github.com/1broseidon/cymbal/lang"
 	"github.com/1broseidon/cymbal/symbols"
 )
 
@@ -88,7 +89,7 @@ func Add(a, b int) int {
 	return a + b
 }
 `)
-	result, err := ParseSource(src, "test.go", "go", languages["go"])
+	result, err := ParseSource(src, "test.go", "go", lang.Default.TreeSitter("go"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -131,7 +132,7 @@ func (s *Server) Start() error {
 func (s *Server) Stop() {
 }
 `)
-	result, err := ParseSource(src, "test.go", "go", languages["go"])
+	result, err := ParseSource(src, "test.go", "go", lang.Default.TreeSitter("go"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -166,7 +167,7 @@ type Handler interface {
 
 type Duration int64
 `)
-	result, err := ParseSource(src, "test.go", "go", languages["go"])
+	result, err := ParseSource(src, "test.go", "go", lang.Default.TreeSitter("go"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -197,7 +198,7 @@ const (
 	StatusError = 500
 )
 `)
-	result, err := ParseSource(src, "test.go", "go", languages["go"])
+	result, err := ParseSource(src, "test.go", "go", lang.Default.TreeSitter("go"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -231,7 +232,7 @@ func main() {
 	fmt.Println("hello")
 }
 `)
-	result, err := ParseSource(src, "test.go", "go", languages["go"])
+	result, err := ParseSource(src, "test.go", "go", lang.Default.TreeSitter("go"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -264,7 +265,7 @@ func main() {
 	greet("world")
 }
 `)
-	result, err := ParseSource(src, "test.go", "go", languages["go"])
+	result, err := ParseSource(src, "test.go", "go", lang.Default.TreeSitter("go"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -287,7 +288,7 @@ func Calculate(x int, y int) int {
 	return x + y
 }
 `)
-	result, err := ParseSource(src, "test.go", "go", languages["go"])
+	result, err := ParseSource(src, "test.go", "go", lang.Default.TreeSitter("go"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -314,7 +315,7 @@ func TestFeaturePythonFunctions(t *testing.T) {
 def calculate(a, b):
     return a + b
 `)
-	result, err := ParseSource(src, "test.py", "python", languages["python"])
+	result, err := ParseSource(src, "test.py", "python", lang.Default.TreeSitter("python"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -342,7 +343,7 @@ class Dog(Animal):
     def speak(self):
         return "Woof!"
 `)
-	result, err := ParseSource(src, "test.py", "python", languages["python"])
+	result, err := ParseSource(src, "test.py", "python", lang.Default.TreeSitter("python"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -374,7 +375,7 @@ def _private_func():
 def __very_private():
     pass
 `)
-	result, err := ParseSource(src, "test.py", "python", languages["python"])
+	result, err := ParseSource(src, "test.py", "python", lang.Default.TreeSitter("python"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -406,7 +407,7 @@ def cached_func(x):
 def static_method():
     pass
 `)
-	result, err := ParseSource(src, "test.py", "python", languages["python"])
+	result, err := ParseSource(src, "test.py", "python", lang.Default.TreeSitter("python"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -425,7 +426,7 @@ func TestFeaturePythonImports(t *testing.T) {
 from pathlib import Path
 from collections import defaultdict
 `)
-	result, err := ParseSource(src, "test.py", "python", languages["python"])
+	result, err := ParseSource(src, "test.py", "python", lang.Default.TreeSitter("python"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -457,7 +458,7 @@ class UserService {
     }
 }
 `)
-	result, err := ParseSource(src, "test.js", "javascript", languages["javascript"])
+	result, err := ParseSource(src, "test.js", "javascript", lang.Default.TreeSitter("javascript"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -480,7 +481,7 @@ const multiply = (a, b) => {
     return a * b;
 };
 `)
-	result, err := ParseSource(src, "test.js", "javascript", languages["javascript"])
+	result, err := ParseSource(src, "test.js", "javascript", lang.Default.TreeSitter("javascript"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -508,7 +509,7 @@ export class ApiClient {
     request(endpoint) {}
 }
 `)
-	result, err := ParseSource(src, "test.js", "javascript", languages["javascript"])
+	result, err := ParseSource(src, "test.js", "javascript", lang.Default.TreeSitter("javascript"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -538,7 +539,7 @@ interface Repository<T> {
     save(item: T): void;
 }
 `)
-	result, err := ParseSource(src, "test.ts", "typescript", languages["typescript"])
+	result, err := ParseSource(src, "test.ts", "typescript", lang.Default.TreeSitter("typescript"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -562,7 +563,7 @@ type Result<T> = {
     error: string | null;
 };
 `)
-	result, err := ParseSource(src, "test.ts", "typescript", languages["typescript"])
+	result, err := ParseSource(src, "test.ts", "typescript", lang.Default.TreeSitter("typescript"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -592,7 +593,7 @@ enum Direction {
     Right,
 }
 `)
-	result, err := ParseSource(src, "test.ts", "typescript", languages["typescript"])
+	result, err := ParseSource(src, "test.ts", "typescript", lang.Default.TreeSitter("typescript"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -619,7 +620,7 @@ pub fn add(a: i32, b: i32) -> i32 {
     a + b
 }
 `)
-	result, err := ParseSource(src, "test.rs", "rust", languages["rust"])
+	result, err := ParseSource(src, "test.rs", "rust", lang.Default.TreeSitter("rust"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -647,7 +648,7 @@ enum Shape {
     Triangle(f64, f64, f64),
 }
 `)
-	result, err := ParseSource(src, "test.rs", "rust", languages["rust"])
+	result, err := ParseSource(src, "test.rs", "rust", lang.Default.TreeSitter("rust"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -669,7 +670,7 @@ func TestFeatureRustTraits(t *testing.T) {
     fn area(&self) -> f64;
 }
 `)
-	result, err := ParseSource(src, "test.rs", "rust", languages["rust"])
+	result, err := ParseSource(src, "test.rs", "rust", lang.Default.TreeSitter("rust"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -695,7 +696,7 @@ impl Circle {
     }
 }
 `)
-	result, err := ParseSource(src, "test.rs", "rust", languages["rust"])
+	result, err := ParseSource(src, "test.rs", "rust", lang.Default.TreeSitter("rust"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -729,7 +730,7 @@ fn main() {
     helper();
 }
 `)
-	result, err := ParseSource(src, "test.rs", "rust", languages["rust"])
+	result, err := ParseSource(src, "test.rs", "rust", lang.Default.TreeSitter("rust"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -788,7 +789,7 @@ fun topLevel(a: Int): Int = a + 1
 
 val GLOBAL = 42
 `)
-	result, err := ParseSource(src, "test.kt", "kotlin", languages["kotlin"])
+	result, err := ParseSource(src, "test.kt", "kotlin", lang.Default.TreeSitter("kotlin"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -939,7 +940,7 @@ void main() {
 
 void doSomething() {}
 `)
-	result, err := ParseSource(src, "test.dart", "dart", languages["dart"])
+	result, err := ParseSource(src, "test.dart", "dart", lang.Default.TreeSitter("dart"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1144,7 +1145,7 @@ int main() {
     return 0;
 }
 `)
-	result, err := ParseSource(src, "test.c", "c", languages["c"])
+	result, err := ParseSource(src, "test.c", "c", lang.Default.TreeSitter("c"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1264,7 +1265,7 @@ int main() {
     return 0;
 }
 `)
-	result, err := ParseSource(src, "test.cpp", "cpp", languages["cpp"])
+	result, err := ParseSource(src, "test.cpp", "cpp", lang.Default.TreeSitter("cpp"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1441,7 +1442,7 @@ fn main() {}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			result, err := ParseSource([]byte(tt.src), tt.file, tt.lang, languages[tt.lang])
+			result, err := ParseSource([]byte(tt.src), tt.file, tt.lang, lang.Default.TreeSitter(tt.lang))
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1475,7 +1476,7 @@ func Second() {}
 
 func Third() {}
 `)
-	result, err := ParseSource(src, "test.go", "go", languages["go"])
+	result, err := ParseSource(src, "test.go", "go", lang.Default.TreeSitter("go"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1510,7 +1511,7 @@ func main() {
 	_ = s
 }
 `)
-	result, err := ParseSource(src, "test.go", "go", languages["go"])
+	result, err := ParseSource(src, "test.go", "go", lang.Default.TreeSitter("go"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1536,7 +1537,7 @@ func main() {
 	_ = m
 }
 `)
-	result, err := ParseSource(src, "test.go", "go", languages["go"])
+	result, err := ParseSource(src, "test.go", "go", lang.Default.TreeSitter("go"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1564,7 +1565,7 @@ func main() {
 	_ = items
 }
 `)
-	result, err := ParseSource(src, "test.go", "go", languages["go"])
+	result, err := ParseSource(src, "test.go", "go", lang.Default.TreeSitter("go"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1585,7 +1586,7 @@ func main() {
 	_ = http.Client{Timeout: 30}
 }
 `)
-	result, err := ParseSource(src, "test.go", "go", languages["go"])
+	result, err := ParseSource(src, "test.go", "go", lang.Default.TreeSitter("go"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1607,7 +1608,7 @@ func main() {
 	_ = m
 }
 `)
-	result, err := ParseSource(src, "test.go", "go", languages["go"])
+	result, err := ParseSource(src, "test.go", "go", lang.Default.TreeSitter("go"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1635,7 +1636,7 @@ func main() {
 	_ = items
 }
 `)
-	result, err := ParseSource(src, "test.go", "go", languages["go"])
+	result, err := ParseSource(src, "test.go", "go", lang.Default.TreeSitter("go"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1657,7 +1658,7 @@ func main() {
 	_ = items
 }
 `)
-	result, err := ParseSource(src, "test.go", "go", languages["go"])
+	result, err := ParseSource(src, "test.go", "go", lang.Default.TreeSitter("go"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1680,7 +1681,7 @@ func TestFeatureJSNewExpressionRef(t *testing.T) {
 
 const obj = new UsedClass("test");
 `)
-	result, err := ParseSource(src, "test.js", "javascript", languages["javascript"])
+	result, err := ParseSource(src, "test.js", "javascript", lang.Default.TreeSitter("javascript"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1705,7 +1706,7 @@ func TestFeatureTSNewExpressionRef(t *testing.T) {
 
 const svc = new Service("api");
 `)
-	result, err := ParseSource(src, "test.ts", "typescript", languages["typescript"])
+	result, err := ParseSource(src, "test.ts", "typescript", lang.Default.TreeSitter("typescript"))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1723,7 +1724,7 @@ const svc = new Service("api");
 func TestFeatureJSNewExpressionMemberRef(t *testing.T) {
 	src := []byte(`const ws = new WebSocket.Server({ port: 8080 });
 `)
-	result, err := ParseSource(src, "test.js", "javascript", languages["javascript"])
+	result, err := ParseSource(src, "test.js", "javascript", lang.Default.TreeSitter("javascript"))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/walker/walker.go
+++ b/walker/walker.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/1broseidon/cymbal/lang"
 )
 
 // FileEntry is a file discovered during walking.
@@ -47,77 +49,10 @@ var skipDirs = map[string]bool{
 	".vscode":      true,
 }
 
-// Language extension mapping.
-var extToLang = map[string]string{
-	".go":      "go",
-	".py":      "python",
-	".js":      "javascript",
-	".jsx":     "javascript",
-	".ts":      "typescript",
-	".tsx":     "typescript",
-	".rs":      "rust",
-	".rb":      "ruby",
-	".java":    "java",
-	".c":       "c",
-	".h":       "c",
-	".cpp":     "cpp",
-	".cc":      "cpp",
-	".hpp":     "cpp",
-	".cls":     "apex",
-	".trigger": "apex",
-	".cs":      "csharp",
-	".swift":   "swift",
-	".kt":      "kotlin",
-	".lua":     "lua",
-	".php":     "php",
-	".sh":      "bash",
-	".bash":    "bash",
-	".zsh":     "bash",
-	".zig":     "zig",
-	".toml":    "toml",
-	".yaml":    "yaml",
-	".yml":     "yaml",
-	".json":    "json",
-	".md":      "markdown",
-	".sql":     "sql",
-	".proto":   "protobuf",
-	".tf":      "hcl",
-	".hcl":     "hcl",
-	".ex":      "elixir",
-	".exs":     "elixir",
-	".erl":     "erlang",
-	".hs":      "haskell",
-	".ml":      "ocaml",
-	".mli":     "ocaml",
-	".scala":   "scala",
-	".r":       "r",
-	".R":       "r",
-	".pl":      "perl",
-	".pm":      "perl",
-	".dart":    "dart",
-	".vue":     "vue",
-	".svelte":  "svelte",
-}
-
 // LangForFile returns the language identifier for a file path.
+// It delegates to the unified language registry in lang.Default.
 func LangForFile(path string) string {
-	ext := filepath.Ext(path)
-	if lang, ok := extToLang[ext]; ok {
-		return lang
-	}
-	// Check special filenames
-	base := filepath.Base(path)
-	switch base {
-	case "Makefile", "makefile", "GNUmakefile":
-		return "make"
-	case "Dockerfile":
-		return "dockerfile"
-	case "Jenkinsfile":
-		return "groovy"
-	case "CMakeLists.txt":
-		return "cmake"
-	}
-	return ""
+	return lang.Default.LangForFile(path)
 }
 
 // Walk concurrently discovers all source files under root.

--- a/walker/walker_feature_test.go
+++ b/walker/walker_feature_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/1broseidon/cymbal/lang"
 )
 
 func createTestTree(t *testing.T) string {
@@ -208,6 +210,91 @@ func TestFeatureWalkerUnknownExtension(t *testing.T) {
 	lang := LangForFile("test.xyz")
 	if lang != "" {
 		t.Errorf("expected empty language for unknown extension, got %q", lang)
+	}
+}
+
+func TestFeatureWalkerRegistryIssue19Extensions(t *testing.T) {
+	tests := []struct {
+		file string
+		lang string
+	}{
+		{"test.cxx", "cpp"},
+		{"test.hxx", "cpp"},
+		{"test.hh", "cpp"},
+		{"test.mjs", "javascript"},
+		{"test.cjs", "javascript"},
+		{"test.mts", "typescript"},
+		{"test.cts", "typescript"},
+		{"test.pyw", "python"},
+		{"test.kts", "kotlin"},
+		{"test.rake", "ruby"},
+		{"test.gemspec", "ruby"},
+		{"test.sc", "scala"},
+		{"test.tfvars", "hcl"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.file, func(t *testing.T) {
+			got := LangForFile(tt.file)
+			if got != tt.lang {
+				t.Errorf("LangForFile(%q) = %q, want %q", tt.file, got, tt.lang)
+			}
+		})
+	}
+}
+
+func TestFeatureWalkerWithSupportedFilterSkipsRecognitionOnly(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string]string{
+		"main.go":       "package main",
+		"module.mjs":    "export const x = 1",
+		"vars.tfvars":   "name = \"demo\"",
+		"config.json":   "{}",
+		"README.md":     "# hi",
+		"Dockerfile":    "FROM alpine",
+		"Makefile":      "all:\n\techo hi\n",
+		"settings.toml": "title = \"demo\"",
+	}
+	for rel, content := range files {
+		full := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(full), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(full, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	walked, err := Walk(dir, 2, lang.Default.Supported)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := make(map[string]string, len(walked))
+	for _, f := range walked {
+		got[f.RelPath] = f.Language
+		if !lang.Default.Supported(f.Language) {
+			t.Fatalf("Walk returned unsupported language %q for %s", f.Language, f.RelPath)
+		}
+	}
+
+	want := map[string]string{
+		"main.go":     "go",
+		"module.mjs":  "javascript",
+		"vars.tfvars": "hcl",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("expected %d parseable files, got %d: %#v", len(want), len(got), got)
+	}
+	for rel, language := range want {
+		if got[rel] != language {
+			t.Errorf("Walk(..., lang.Default.Supported) missing or wrong for %s: got %q want %q", rel, got[rel], language)
+		}
+	}
+	for _, rel := range []string{"config.json", "README.md", "Dockerfile", "Makefile", "settings.toml"} {
+		if _, ok := got[rel]; ok {
+			t.Errorf("Walk(..., lang.Default.Supported) should skip non-parseable file %s", rel)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- unify language recognition and parseability behind a new `lang` registry package
- make `walker`, `parser`, and `index` derive language decisions from the same source of truth
- add the issue #19 extension mappings for already-supported languages (`.cxx/.hxx/.hh`, `.mjs/.cjs`, `.mts/.cts`, `.pyw`, `.kts`, `.rake/.gemspec`, `.sc`, `.tfvars`)
- add focused registry and walker tests covering both the new mappings and supported-language filtering

Closes #19

## Testing

- Commands run:
  - `go test ./lang ./parser ./walker -count=1`
- Extra validation:
  - `go build ./...`
  - `go vet ./...`
  - full `go test ./...` still hits the pre-existing local sqlite/FTS5 environment issue in `index` tests

## Checklist

- [x] I ran the required checks locally, or I explained why I could not in the Testing section.
- [x] I reviewed the diff for unrelated, generated, or vendored changes.
- [x] I updated docs, benchmarks, or release notes when behavior changed, or I explained why no updates were needed.
- [x] I filled out the Security Notes section below.

## Security Notes

- No new network, auth, or permission changes.
- This change centralizes language classification logic and test coverage; it does not expand trust boundaries.

## Risks / Rollout

- Low risk: this is a refactor to unify language classification and parser support behind one registry.
- Main rollout concern is language-mapping regressions, which are covered by the new registry and walker tests.
- No schema, migration, or operational rollout steps are required.