### PR TITLE
fix(outline): wire up --names flag (#28)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to cymbal are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **`cymbal outline --names`** (fixes [#28](https://github.com/1broseidon/cymbal/issues/28)) — emit one deduplicated symbol name per line. This flag was already documented in the `impact`/`trace`/`show` help text and earlier CHANGELOG entries for pipe-driven multi-symbol workflows (`cymbal outline big.go -s --names | cymbal show --stdin`), but the flag itself had never been wired up.
+
 ## [0.11.2] - 2026-04-18
 
 ### Changed

--- a/cmd/outline.go
+++ b/cmd/outline.go
@@ -24,6 +24,7 @@ var outlineCmd = &cobra.Command{
 		ensureFresh(dbPath)
 		jsonOut := getJSONFlag(cmd)
 		sigs, _ := cmd.Flags().GetBool("signatures")
+		namesOnly, _ := cmd.Flags().GetBool("names")
 
 		symbols, err := index.FileOutline(dbPath, filePath)
 		if err != nil {
@@ -37,6 +38,25 @@ var outlineCmd = &cobra.Command{
 		}
 
 		relPath := args[0]
+
+		// --names: one symbol name per line, pipe-friendly for --stdin consumers.
+		if namesOnly {
+			var out strings.Builder
+			seen := make(map[string]struct{}, len(symbols))
+			for _, s := range symbols {
+				if s.Name == "" {
+					continue
+				}
+				if _, ok := seen[s.Name]; ok {
+					continue
+				}
+				seen[s.Name] = struct{}{}
+				out.WriteString(s.Name)
+				out.WriteByte('\n')
+			}
+			fmt.Print(out.String())
+			return nil
+		}
 
 		var content strings.Builder
 		for _, s := range symbols {
@@ -64,5 +84,6 @@ var outlineCmd = &cobra.Command{
 
 func init() {
 	outlineCmd.Flags().BoolP("signatures", "s", false, "show full parameter signatures")
+	outlineCmd.Flags().Bool("names", false, "emit one symbol name per line (pipe-friendly for --stdin)")
 	rootCmd.AddCommand(outlineCmd)
 }


### PR DESCRIPTION
Fixes #28.

`--names` was already documented in `cymbal impact/trace/show --help` and in earlier CHANGELOG entries describing the pipe workflow:

    cymbal outline big.go -s --names | cymbal show --stdin

…but the flag was never declared on `outline`, so it errored out as `unknown flag: --names`.

This wires it up: one deduplicated symbol name per line, pipe-friendly for `--stdin` consumers. `-s`/`--json` are ignored in names-only mode so downstream readers get clean input.

### Verification

```
$ cymbal outline cmd/outline.go --names
outlineCmd
out
content
init
```

`go test ./...` passes.