### PR TITLE
feat(cmd): add `cymbal version` and `--version` (#26)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -68,7 +68,12 @@ jobs:
       - name: Build
         run: |
           EXT=""
-          LDFLAGS="-s -w"
+          TAG="${{ steps.ref.outputs.ref }}"
+          TAG="${TAG#refs/tags/}"
+          COMMIT="$(git rev-parse HEAD)"
+          DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          VERSION_PKG="github.com/1broseidon/cymbal/cmd"
+          LDFLAGS="-s -w -X ${VERSION_PKG}.version=${TAG} -X ${VERSION_PKG}.commit=${COMMIT} -X ${VERSION_PKG}.date=${DATE}"
           CGO_FLAGS="-DSQLITE_ENABLE_FTS5"
           if [ "${{ matrix.goos }}" = "windows" ]; then
             EXT=".exe"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ All notable changes to cymbal are documented here.
 
 ### Added
 
+- **`cymbal version` and `--version`** (fixes [#26](https://github.com/1broseidon/cymbal/issues/26)) — print the binary version, commit, build date, and Go toolchain. Release builds embed the tag, commit, and timestamp via `-ldflags`; `go install`-style builds fall back to `debug.ReadBuildInfo()` so module version and VCS stamp still surface. JSON mode is available via `--json`.
 - **`cymbal outline --names`** (fixes [#28](https://github.com/1broseidon/cymbal/issues/28)) — emit one deduplicated symbol name per line. This flag was already documented in the `impact`/`trace`/`show` help text and earlier CHANGELOG entries for pipe-driven multi-symbol workflows (`cymbal outline big.go -s --names | cymbal show --stdin`), but the flag itself had never been wired up.
 
 ## [0.11.2] - 2026-04-18

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,22 @@
 BINARY := cymbal
 CGO_CFLAGS := -DSQLITE_ENABLE_FTS5
 
+VERSION ?= $(shell git describe --tags --always --dirty 2>/dev/null || echo dev)
+COMMIT  ?= $(shell git rev-parse HEAD 2>/dev/null || echo unknown)
+DATE    ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
+VERSION_PKG := github.com/1broseidon/cymbal/cmd
+LDFLAGS := -X $(VERSION_PKG).version=$(VERSION) -X $(VERSION_PKG).commit=$(COMMIT) -X $(VERSION_PKG).date=$(DATE)
+
 .PHONY: build build-check ci clean install lint test vulncheck
 
 build:
-	CGO_CFLAGS="$(CGO_CFLAGS)" go build -o $(BINARY) .
+	CGO_CFLAGS="$(CGO_CFLAGS)" go build -ldflags "$(LDFLAGS)" -o $(BINARY) .
 
 build-check:
 	CGO_CFLAGS="$(CGO_CFLAGS)" go build ./...
 
 install:
-	CGO_CFLAGS="$(CGO_CFLAGS)" go install .
+	CGO_CFLAGS="$(CGO_CFLAGS)" go install -ldflags "$(LDFLAGS)" .
 
 test:
 	CGO_CFLAGS="$(CGO_CFLAGS)" go test ./...

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"fmt"
+	"runtime"
+	"runtime/debug"
+
+	"github.com/spf13/cobra"
+)
+
+// Build-time version info. Set via -ldflags "-X github.com/1broseidon/cymbal/cmd.version=..."
+// by goreleaser/CI. Defaults below are used for `go install` / dev builds, where we fall back
+// to debug.ReadBuildInfo() to surface the module version and VCS stamp.
+var (
+	version = "dev"
+	commit  = ""
+	date    = ""
+)
+
+// versionInfo resolves version/commit/date, preferring linker-provided values and falling
+// back to runtime build info so `go install github.com/1broseidon/cymbal@vX.Y.Z` still
+// reports a useful version.
+func versionInfo() (v, c, d string) {
+	v, c, d = version, commit, date
+	if v != "dev" && v != "" {
+		return
+	}
+	bi, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	if bi.Main.Version != "" && bi.Main.Version != "(devel)" {
+		v = bi.Main.Version
+	}
+	for _, s := range bi.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			if c == "" {
+				c = s.Value
+			}
+		case "vcs.time":
+			if d == "" {
+				d = s.Value
+			}
+		}
+	}
+	return
+}
+
+func shortVersion() string {
+	v, c, _ := versionInfo()
+	if c != "" && len(c) >= 7 && (v == "dev" || v == "") {
+		return fmt.Sprintf("dev (%s)", c[:7])
+	}
+	return v
+}
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print cymbal version information",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		v, c, d := versionInfo()
+		jsonOut := getJSONFlag(cmd)
+		if jsonOut {
+			payload := map[string]string{
+				"version": v,
+				"commit":  c,
+				"date":    d,
+				"go":      runtime.Version(),
+				"os":      runtime.GOOS,
+				"arch":    runtime.GOARCH,
+			}
+			return renderJSONOrFrontmatter(true, payload, nil, "")
+		}
+		fmt.Printf("cymbal %s\n", v)
+		if c != "" {
+			fmt.Printf("  commit: %s\n", c)
+		}
+		if d != "" {
+			fmt.Printf("  built:  %s\n", d)
+		}
+		fmt.Printf("  go:     %s %s/%s\n", runtime.Version(), runtime.GOOS, runtime.GOARCH)
+		return nil
+	},
+}
+
+func init() {
+	rootCmd.Version = shortVersion()
+	// Cobra emits "cymbal version X" for --version by default; keep it short.
+	rootCmd.SetVersionTemplate("cymbal {{.Version}}\n")
+	rootCmd.AddCommand(versionCmd)
+}


### PR DESCRIPTION
Closes #26.

Agents and users had no way to ask which cymbal they were running, which made bug reports hard to triage.

### What this adds

- **`cymbal version` subcommand** — prints version, commit, build date, Go toolchain, OS/arch. `--json` supported.
- **`cymbal --version`** — short one-liner via cobra's `rootCmd.Version`.
- **Release wiring** — `release.yml` and `Makefile` pass `-ldflags -X github.com/1broseidon/cymbal/cmd.{version,commit,date}=…` so tagged builds embed the real values.
- **`go install` fallback** — if no ldflags are set, `debug.ReadBuildInfo()` fills in the module version and VCS stamp, so `go install …@vX.Y.Z` still reports a useful version.

### Verification

```
$ make build
$ ./cymbal --version
cymbal v0.11.2-1-g70efa1b-dirty
$ ./cymbal version
cymbal v0.11.2-1-g70efa1b-dirty
  commit: 70efa1b375185f87fc2c87aff8a7c14fc49f9b1e
  built:  2026-04-20T02:27:53Z
  go:     go1.25.8 linux/amd64
$ ./cymbal version --json
{ "version": "v0.11.2-1-g70efa1b-dirty", "commit": "...", "go": "go1.25.8", ... }
```

`go test ./...` and `go vet ./...` pass.