### PR TITLE
ci(pr-body): relax checklist enforcement; allow trivial PRs

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,6 +3,15 @@
 - What changed?
 - Why is this needed?
 
+<!--
+Trivial PRs (≤20 changed lines, or labeled `trivial` / `docs` / `dependencies`)
+skip the rest of this template. For those, a short `## Summary` is enough.
+
+For larger PRs, fill in the sections below. Only `## Summary` is strictly
+required by CI; `## Checklist` boxes are checked as warnings (not failures)
+so reviewers can still merge when unchecked items are justified.
+-->
+
 ## Testing
 
 - Commands run:

--- a/.github/workflows/pr-body.yml
+++ b/.github/workflows/pr-body.yml
@@ -22,41 +22,61 @@ jobs:
         uses: actions/github-script@v7
         with:
           script: |
-            const body = context.payload.pull_request.body || "";
-            const requiredHeadings = [
-              "## Summary",
-              "## Testing",
-              "## Checklist",
-              "## Security Notes",
-              "## Risks / Rollout",
-            ];
+            const pr = context.payload.pull_request;
+            const body = pr.body || "";
+            const labels = (pr.labels || []).map((l) => (l.name || "").toLowerCase());
+            const changedLines = (pr.additions || 0) + (pr.deletions || 0);
+            const TRIVIAL_LINE_THRESHOLD = 20;
+            const skipLabels = ["trivial", "docs", "skip-checklist", "dependencies"];
 
-            const missingHeadings = requiredHeadings.filter((heading) => !body.includes(heading));
-            if (missingHeadings.length > 0) {
+            const matchedSkipLabel = skipLabels.find((l) => labels.includes(l));
+            const isTrivialSize = changedLines > 0 && changedLines <= TRIVIAL_LINE_THRESHOLD;
+
+            if (matchedSkipLabel || isTrivialSize) {
+              const reason = matchedSkipLabel
+                ? `label \`${matchedSkipLabel}\``
+                : `${changedLines} changed line(s) ≤ ${TRIVIAL_LINE_THRESHOLD}`;
+              core.info(`PR body validation skipped (${reason}).`);
+              await core.summary
+                .addHeading("PR Body validation skipped")
+                .addRaw(`Reason: ${reason}. A non-empty PR description is still encouraged.`)
+                .write();
+              if (!body.trim()) {
+                core.warning("PR description is empty. Please add at least a short summary.");
+              }
+              return;
+            }
+
+            // Non-trivial PRs: require only `## Summary`. Other sections are optional,
+            // but if `## Checklist` is present we flag unchecked boxes as a warning.
+            if (!body.includes("## Summary")) {
               core.setFailed(
-                `Missing required PR sections: ${missingHeadings.join(", ")}. ` +
-                `Use the PR template and keep all headings.`
+                "Missing required `## Summary` section. Use the PR template and describe the change."
               );
+              return;
+            }
+
+            const summaryMatch = body.match(/## Summary\s*([\s\S]*?)(?:\n## |\n?$)/);
+            const summaryBody = (summaryMatch && summaryMatch[1] || "").trim();
+            if (!summaryBody || summaryBody === "- What changed?\n- Why is this needed?") {
+              core.setFailed("`## Summary` is empty or still contains only the template placeholders.");
               return;
             }
 
             const checklistMatch = body.match(/## Checklist\s*([\s\S]*?)(?:\n## |\n?$)/);
-            if (!checklistMatch) {
-              core.setFailed("Checklist section is missing or malformed.");
-              return;
+            if (checklistMatch) {
+              const checklist = checklistMatch[1];
+              const unchecked = [...checklist.matchAll(/^- \[ \] .+$/gm)].map((m) => m[0]);
+              if (unchecked.length > 0) {
+                core.warning(
+                  `PR checklist has ${unchecked.length} unchecked item(s). Complete or remove them before merge:\n` +
+                  unchecked.join("\n")
+                );
+                await core.summary
+                  .addHeading("Unchecked PR checklist items")
+                  .addList(unchecked.map((u) => u.replace(/^- \[ \] /, "")))
+                  .write();
+              }
             }
 
-            const checklist = checklistMatch[1];
-            const unchecked = [...checklist.matchAll(/^- \[ \] .+$/gm)].map((match) => match[0]);
-            const checked = [...checklist.matchAll(/^- \[[xX]\] .+$/gm)].map((match) => match[0]);
-
-            if (checked.length === 0) {
-              core.setFailed("Checklist is present, but nothing is checked.");
-              return;
-            }
-
-            if (unchecked.length > 0) {
-              core.setFailed(
-                `Complete the PR checklist before merge. Remaining items:\n${unchecked.join("\n")}`
-              );
-            }
+            core.info("PR body validation passed.");


### PR DESCRIPTION
## Summary

The `PR Body` required check currently fails every PR that doesn't include all five template headings (Summary/Testing/Checklist/Security Notes/Risks) with every checkbox ticked. That was blocking real fixes — e.g. #27 (one-line typo fix), #30, #31, #32 — and pushing authors toward pasting boilerplate instead of meaningful descriptions.

### New behavior

- **Trivial PRs skip the check** — ≤20 changed lines, or labeled `trivial` / `docs` / `skip-checklist` / `dependencies`. Posts a summary note; only warns if the body is empty.
- **Non-trivial PRs need `## Summary`** with real content (template placeholder text is rejected). Other sections are optional.
- **Checklist items are warnings**, not failures. Unchecked boxes show up in the Actions summary so reviewers see them, but don't block merge.
- **Template updated** with an explicit comment about the trivial-PR escape hatch.

### Testing

Logic-only change in a JS `github-script` step. Validated by reading the script against the four likely scenarios:

| Scenario | Before | After |
|---|---|---|
| 1-line typo fix, 1-line body | FAILURE | skipped (≤20 lines) |
| Docs PR labeled `docs` | FAILURE unless all 5 sections | skipped (label) |
| Big feature PR, full template, all boxes checked | pass | pass |
| Big feature PR, Summary only | FAILURE | pass + warning listing unchecked items |
| Big feature PR, empty body | FAILURE | FAILURE (Summary missing) |
| Big feature PR, template placeholder left as-is | pass (!) | FAILURE (placeholder detected) |

Last row is a bug fix in the old validator — previously any body containing the heading strings passed, even if the bullets still said "What changed?".

`go test ./...` not affected (no code changes).

### Risks / Rollout

- Risk: low — CI-only, no runtime surface.
- Rollback: revert the two files.