### PR TITLE
feat(parser): dedicated coverage for C#, PHP, Lua, Bash (#22 phase 1+2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ All notable changes to cymbal are documented here.
 
   This directly improves `cymbal refs`, `cymbal depends` (PR #18), and `cymbal dead` (PR #17) accuracy on these languages. YAML is intentionally left in the generic path — its semantic model (no functions, no imports, no calls) doesn't fit cymbal's indexed shape. Swift, which was listed in #22, already had dedicated coverage before this change.
 
+- **`cymbal refs --stdin`** — `refs` now accepts newline-separated symbol names on stdin, matching `show` / `impact` / `trace` / `impls`. This finishes the documented pipe idiom (`cymbal outline big.go -s --names | cymbal refs --stdin`) that was previously rejected as `unknown flag: --stdin`.
+
 ## [0.11.3] - 2026-04-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to cymbal are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **Dedicated parser coverage for C#, PHP, Lua, and Bash** (part of [#22](https://github.com/1broseidon/cymbal/issues/22)) — these four languages were parseable by tree-sitter but still falling through to generic symbol extraction, which left them with missing kinds and empty import/reference graphs. Each now has proper `classify` / `extractImport` / `extractRef` paths:
+  - **C#** — `namespace`, `class`, `struct`, `interface`, `enum`, `record`, `delegate`, `method`, `constructor`, `destructor`, `property`, `field`; `using` / `using static` imports; `invocation_expression` and `object_creation_expression` refs.
+  - **PHP** — `namespace`, `class`, `interface`, `trait`, `enum`, `function`, `method`, `const_element`, `enum_case`; `namespace_use_declaration` imports; `function_call_expression`, `member_call_expression`, `scoped_call_expression`, `nullsafe_member_call_expression`, and `object_creation_expression` refs.
+  - **Lua** — `function` / `method` symbols from `function_statement` (including `M.foo` and `M:new` forms); `require("x")` / `require "x"` / `require 'x'` imports; call refs for flat `util.debug(...)` / `M:new(...)` shapes.
+  - **Bash** — `function` symbols from `function_definition`; `source x.sh` / `. x.sh` imports; command-invocation refs with a small ignore list for control-flow builtins (`if`/`for`/`set`/`local`/etc.) so real call signal isn't drowned by keywords.
+
+  This directly improves `cymbal refs`, `cymbal depends` (PR #18), and `cymbal dead` (PR #17) accuracy on these languages. YAML is intentionally left in the generic path — its semantic model (no functions, no imports, no calls) doesn't fit cymbal's indexed shape. Swift, which was listed in #22, already had dedicated coverage before this change.
+
 ## [0.11.3] - 2026-04-20
 
 ### Added

--- a/cmd/refs.go
+++ b/cmd/refs.go
@@ -19,9 +19,11 @@ Default: shows call-expression references across indexed files.
 --impact: shorthand for --importers --depth 2 (transitive impact).
 
 Supports batch: cymbal refs Foo Bar Baz
+Also accepts newline-separated names on stdin via --stdin:
+  cymbal outline foo.go -s --names | cymbal refs --stdin
 
 Note: references are best-effort based on AST name matching, not semantic analysis.`,
-	Args: cobra.MinimumNArgs(1),
+	Args: cobra.MinimumNArgs(0),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		dbPath := getDBPath(cmd)
 		ensureFresh(dbPath)
@@ -45,7 +47,12 @@ Note: references are best-effort based on AST name matching, not semantic analys
 			}
 		}
 
-		for i, name := range args {
+		names, err := collectSymbols(cmd, args)
+		if err != nil {
+			return err
+		}
+
+		for i, name := range names {
 			if i > 0 {
 				fmt.Println()
 			}
@@ -72,6 +79,7 @@ func init() {
 	refsCmd.Flags().StringArray("path", nil, "include only results whose path matches this glob (repeatable)")
 	refsCmd.Flags().StringArray("exclude", nil, "exclude results whose path matches this glob (repeatable)")
 	refsCmd.Flags().String("file", "", "restrict refs to files that import or include the given path fragment")
+	addStdinFlag(refsCmd)
 	rootCmd.AddCommand(refsCmd)
 }
 

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -149,6 +149,14 @@ func (e *symbolExtractor) extractImport(node *sitter.Node) (symbols.Import, bool
 		return e.extractImportDart(nodeType, node)
 	case "swift":
 		return e.extractImportSwift(nodeType, node)
+	case "csharp":
+		return e.extractImportCSharp(nodeType, node)
+	case "php":
+		return e.extractImportPHP(nodeType, node)
+	case "lua":
+		return e.extractImportLua(nodeType, node)
+	case "bash":
+		return e.extractImportBash(nodeType, node)
 	}
 	return symbols.Import{}, false
 }
@@ -291,6 +299,14 @@ func (e *symbolExtractor) extractRef(node *sitter.Node) (symbols.Ref, bool) {
 		return e.extractRefDart(nodeType, node)
 	case "swift":
 		return e.extractRefSwift(nodeType, node)
+	case "csharp":
+		return e.extractRefCSharp(nodeType, node)
+	case "php":
+		return e.extractRefPHP(nodeType, node)
+	case "lua":
+		return e.extractRefLua(nodeType, node)
+	case "bash":
+		return e.extractRefBash(nodeType, node)
 	}
 	return symbols.Ref{}, false
 }
@@ -594,6 +610,14 @@ func (e *symbolExtractor) classifyNode(nodeType string, node *sitter.Node) (stri
 		return e.classifyDart(nodeType, node)
 	case "swift":
 		return e.classifySwift(nodeType, node)
+	case "csharp":
+		return e.classifyCSharp(nodeType, node)
+	case "php":
+		return e.classifyPHP(nodeType, node)
+	case "lua":
+		return e.classifyLua(nodeType, node)
+	case "bash":
+		return e.classifyBash(nodeType, node)
 	default:
 		return e.classifyGeneric(nodeType, node)
 	}
@@ -1400,6 +1424,468 @@ func swiftSignature(node *sitter.Node, src []byte) string {
 		return ""
 	}
 	return strings.TrimSpace(string(src[start:end]))
+}
+
+// --- C# ---
+//
+// Grammar refs (tree-sitter-c-sharp):
+//   using_directive            → "using Foo.Bar;" / "using static System.Math;"
+//   namespace_declaration      → "namespace X { ... }"
+//   class_declaration / struct_declaration / interface_declaration /
+//   enum_declaration / record_declaration — all expose a `name` child
+//   method_declaration / constructor_declaration / destructor_declaration /
+//   property_declaration / field_declaration / delegate_declaration
+//   invocation_expression      → function is `function` field
+//   object_creation_expression → first identifier/qualified_name after `new`
+//   member_access_expression   → x.Y — reference to Y
+
+func (e *symbolExtractor) classifyCSharp(nodeType string, node *sitter.Node) (string, *sitter.Node) {
+	switch nodeType {
+	case "namespace_declaration", "file_scoped_namespace_declaration":
+		return "namespace", node.ChildByFieldName("name")
+	case "class_declaration":
+		return "class", node.ChildByFieldName("name")
+	case "struct_declaration":
+		return "struct", node.ChildByFieldName("name")
+	case "interface_declaration":
+		return "interface", node.ChildByFieldName("name")
+	case "enum_declaration":
+		return "enum", node.ChildByFieldName("name")
+	case "record_declaration", "record_struct_declaration":
+		return "record", node.ChildByFieldName("name")
+	case "delegate_declaration":
+		return "delegate", node.ChildByFieldName("name")
+	case "method_declaration":
+		return "method", node.ChildByFieldName("name")
+	case "constructor_declaration":
+		return "constructor", node.ChildByFieldName("name")
+	case "destructor_declaration":
+		return "destructor", node.ChildByFieldName("name")
+	case "property_declaration", "indexer_declaration":
+		return "property", node.ChildByFieldName("name")
+	case "field_declaration":
+		// field_declaration → variable_declaration → variable_declarator(name)
+		if vd := findChildByType(node, "variable_declaration"); vd != nil {
+			if decl := findChildByType(vd, "variable_declarator"); decl != nil {
+				if name := decl.ChildByFieldName("name"); name != nil {
+					return "field", name
+				}
+			}
+		}
+	case "enum_member_declaration":
+		return "constant", node.ChildByFieldName("name")
+	}
+	return "", nil
+}
+
+func (e *symbolExtractor) extractImportCSharp(nodeType string, node *sitter.Node) (symbols.Import, bool) {
+	if nodeType != "using_directive" {
+		return symbols.Import{}, false
+	}
+	// Strip leading `using ` / `using static ` and trailing `;`, normalize whitespace.
+	raw := strings.TrimSpace(node.Content(e.src))
+	raw = strings.TrimSuffix(raw, ";")
+	raw = strings.TrimSpace(strings.TrimPrefix(raw, "using"))
+	raw = strings.TrimSpace(strings.TrimPrefix(raw, "static"))
+	if raw == "" {
+		return symbols.Import{}, false
+	}
+	return symbols.Import{RawPath: raw, Language: e.lang}, true
+}
+
+func (e *symbolExtractor) extractRefCSharp(nodeType string, node *sitter.Node) (symbols.Ref, bool) {
+	line := int(node.StartPoint().Row) + 1
+	switch nodeType {
+	case "invocation_expression":
+		fn := node.ChildByFieldName("function")
+		if fn == nil && node.ChildCount() > 0 {
+			fn = node.Child(0)
+		}
+		if fn == nil {
+			return symbols.Ref{}, false
+		}
+		name := extractCallName(fn, e.src, e.lang)
+		if name == "" {
+			return symbols.Ref{}, false
+		}
+		return symbols.Ref{Name: name, Line: line, Language: e.lang, Kind: symbols.RefKindCall}, true
+	case "object_creation_expression":
+		// `new Foo(...)` or `new N.Foo(...)` — emit Foo.
+		typeNode := node.ChildByFieldName("type")
+		if typeNode == nil {
+			// Fall back: first identifier or qualified_name after `new`.
+			for i := 0; i < int(node.ChildCount()); i++ {
+				c := node.Child(i)
+				if c.Type() == "identifier" || c.Type() == "qualified_name" || c.Type() == "generic_name" {
+					typeNode = c
+					break
+				}
+			}
+		}
+		if typeNode == nil {
+			return symbols.Ref{}, false
+		}
+		name := extractCallName(typeNode, e.src, e.lang)
+		if name == "" {
+			return symbols.Ref{}, false
+		}
+		return symbols.Ref{Name: name, Line: line, Language: e.lang, Kind: symbols.RefKindCall}, true
+	}
+	return symbols.Ref{}, false
+}
+
+// --- PHP ---
+//
+// Grammar refs (tree-sitter-php):
+//   namespace_use_declaration  → "use Foo\\Bar;" / "use Foo\\Bar as Baz;"
+//   namespace_definition       → "namespace Foo\\Bar;"
+//   class_declaration / interface_declaration / trait_declaration /
+//   enum_declaration — `name` field
+//   function_definition / method_declaration — `name` field
+//   function_call_expression   → function field
+//   member_call_expression     → name field is method
+//   scoped_call_expression     → name field is method (Foo::bar())
+//   object_creation_expression → first type after `new`
+
+func (e *symbolExtractor) classifyPHP(nodeType string, node *sitter.Node) (string, *sitter.Node) {
+	switch nodeType {
+	case "namespace_definition":
+		return "namespace", node.ChildByFieldName("name")
+	case "class_declaration":
+		return "class", node.ChildByFieldName("name")
+	case "interface_declaration":
+		return "interface", node.ChildByFieldName("name")
+	case "trait_declaration":
+		return "trait", node.ChildByFieldName("name")
+	case "enum_declaration":
+		return "enum", node.ChildByFieldName("name")
+	case "function_definition":
+		return "function", node.ChildByFieldName("name")
+	case "method_declaration":
+		return "method", node.ChildByFieldName("name")
+	case "const_element":
+		// const_element has `name` field; parent const_declaration wraps it.
+		return "constant", node.ChildByFieldName("name")
+	case "enum_case":
+		return "constant", node.ChildByFieldName("name")
+	}
+	return "", nil
+}
+
+func (e *symbolExtractor) extractImportPHP(nodeType string, node *sitter.Node) (symbols.Import, bool) {
+	if nodeType != "namespace_use_declaration" {
+		return symbols.Import{}, false
+	}
+	// Emit one import per `namespace_use_clause` child; fallback to raw text.
+	for i := 0; i < int(node.ChildCount()); i++ {
+		c := node.Child(i)
+		if c.Type() == "namespace_use_clause" {
+			// First qualified_name / namespace_name / name child is the path.
+			for j := 0; j < int(c.ChildCount()); j++ {
+				cc := c.Child(j)
+				switch cc.Type() {
+				case "qualified_name", "namespace_name", "name":
+					return symbols.Import{RawPath: cc.Content(e.src), Language: e.lang}, true
+				}
+			}
+			return symbols.Import{RawPath: c.Content(e.src), Language: e.lang}, true
+		}
+	}
+	return symbols.Import{}, false
+}
+
+func (e *symbolExtractor) extractRefPHP(nodeType string, node *sitter.Node) (symbols.Ref, bool) {
+	line := int(node.StartPoint().Row) + 1
+	switch nodeType {
+	case "function_call_expression":
+		fn := node.ChildByFieldName("function")
+		if fn == nil {
+			return symbols.Ref{}, false
+		}
+		name := extractCallName(fn, e.src, e.lang)
+		if name == "" {
+			return symbols.Ref{}, false
+		}
+		return symbols.Ref{Name: name, Line: line, Language: e.lang, Kind: symbols.RefKindCall}, true
+	case "member_call_expression", "scoped_call_expression", "nullsafe_member_call_expression":
+		nameNode := node.ChildByFieldName("name")
+		if nameNode == nil {
+			return symbols.Ref{}, false
+		}
+		name := strings.TrimSpace(nameNode.Content(e.src))
+		if name == "" {
+			return symbols.Ref{}, false
+		}
+		return symbols.Ref{Name: name, Line: line, Language: e.lang, Kind: symbols.RefKindCall}, true
+	case "object_creation_expression":
+		// Walk children for the first name/qualified_name/named_type.
+		for i := 0; i < int(node.ChildCount()); i++ {
+			c := node.Child(i)
+			switch c.Type() {
+			case "name", "qualified_name", "named_type":
+				name := extractCallName(c, e.src, e.lang)
+				if name == "" {
+					continue
+				}
+				return symbols.Ref{Name: name, Line: line, Language: e.lang, Kind: symbols.RefKindCall}, true
+			}
+		}
+	}
+	return symbols.Ref{}, false
+}
+
+// --- Lua ---
+//
+// Grammar refs (tree-sitter-lua, smacker fork):
+//   function_statement         → "function Foo() end" / "function M.foo() end" /
+//                                "local function helper() end"
+//     children: optional `local`, function_start, function_name (or identifier),
+//               function_body_paren, parameter_list, function_body, function_end
+//   function_name              → M.greet / M:new (table_dot / : separators)
+//   function_call              → identifier | dot_index_expression | method_index_expression
+//                                followed by function_arguments
+//   require("x") / require "x" are function_call forms — handled as imports.
+
+func (e *symbolExtractor) classifyLua(nodeType string, node *sitter.Node) (string, *sitter.Node) {
+	if nodeType != "function_statement" {
+		return "", nil
+	}
+	// function_name child for "function X.y()" and "function X()";
+	// identifier child for "local function helper()".
+	if fn := findChildByType(node, "function_name"); fn != nil {
+		// Emit the method name (last identifier in M.greet / M:new).
+		kind := "function"
+		// Treat `M:method` as method.
+		if strings.Contains(fn.Content(e.src), ":") {
+			kind = "method"
+		}
+		if id := lastIdentifier(fn); id != nil {
+			return kind, id
+		}
+		return kind, fn
+	}
+	if id := findChildByType(node, "identifier"); id != nil {
+		return "function", id
+	}
+	return "", nil
+}
+
+// lastIdentifier returns the last direct `identifier` child of n (for
+// Lua function_name nodes like M.greet / M:new).
+func lastIdentifier(n *sitter.Node) *sitter.Node {
+	var last *sitter.Node
+	for i := 0; i < int(n.ChildCount()); i++ {
+		c := n.Child(i)
+		if c.Type() == "identifier" {
+			last = c
+		}
+	}
+	return last
+}
+
+func (e *symbolExtractor) extractImportLua(nodeType string, node *sitter.Node) (symbols.Import, bool) {
+	if nodeType != "function_call" {
+		return symbols.Import{}, false
+	}
+	// First child must be identifier "require".
+	if node.ChildCount() == 0 {
+		return symbols.Import{}, false
+	}
+	callee := node.Child(0)
+	if callee.Type() != "identifier" || strings.TrimSpace(callee.Content(e.src)) != "require" {
+		return symbols.Import{}, false
+	}
+	// Argument shapes in tree-sitter-lua (smacker fork):
+	//   require("x") → function_arguments wrapping string
+	//   require "x"  → string_argument (direct wrapper with string_start/_content/_end)
+	//   require 'x'  → same as above
+	for i := 1; i < int(node.ChildCount()); i++ {
+		c := node.Child(i)
+		switch c.Type() {
+		case "function_arguments", "string_argument":
+			if s := findDescendantString(c, e.src); s != "" {
+				return symbols.Import{RawPath: s, Language: e.lang}, true
+			}
+		case "string":
+			if s := luaStringContent(c, e.src); s != "" {
+				return symbols.Import{RawPath: s, Language: e.lang}, true
+			}
+		}
+	}
+	return symbols.Import{}, false
+}
+
+// findDescendantString walks a subtree looking for the first string node
+// (including string_argument / string_content) and returns its unquoted content.
+func findDescendantString(n *sitter.Node, src []byte) string {
+	if n == nil {
+		return ""
+	}
+	switch n.Type() {
+	case "string_content":
+		return n.Content(src)
+	case "string", "string_argument":
+		return luaStringContent(n, src)
+	}
+	for i := 0; i < int(n.ChildCount()); i++ {
+		if s := findDescendantString(n.Child(i), src); s != "" {
+			return s
+		}
+	}
+	return ""
+}
+
+func luaStringContent(n *sitter.Node, src []byte) string {
+	// tree-sitter-lua: string → string_start "string_content" string_end
+	if c := findChildByType(n, "string_content"); c != nil {
+		return c.Content(src)
+	}
+	// Fallback: strip surrounding quotes.
+	raw := n.Content(src)
+	if len(raw) >= 2 && (raw[0] == '"' || raw[0] == '\'') {
+		return raw[1 : len(raw)-1]
+	}
+	return raw
+}
+
+func (e *symbolExtractor) extractRefLua(nodeType string, node *sitter.Node) (symbols.Ref, bool) {
+	if nodeType != "function_call" {
+		return symbols.Ref{}, false
+	}
+	if node.ChildCount() == 0 {
+		return symbols.Ref{}, false
+	}
+	first := node.Child(0)
+	// Don't emit a ref for `require(...)` — it's surfaced as an import.
+	if first.Type() == "identifier" && strings.TrimSpace(first.Content(e.src)) == "require" {
+		return symbols.Ref{}, false
+	}
+	// tree-sitter-lua (smacker fork) flattens `util.debug(…)` and `M:new(…)`
+	// into a child list:
+	//   function_call
+	//     identifier            ← receiver (for method-like forms)
+	//     '.' | self_call_colon
+	//     identifier            ← method/field name
+	//     function_call_paren   ← '('
+	// Walk children up to the opening paren and pick the last `identifier`,
+	// which is the callable name. For simple `foo(…)` this is still just the
+	// first identifier.
+	var name string
+	for i := 0; i < int(node.ChildCount()); i++ {
+		c := node.Child(i)
+		if c.Type() == "function_call_paren" || c.Type() == "function_arguments" ||
+			c.Type() == "string_argument" || c.Type() == "string" {
+			break
+		}
+		if c.Type() == "identifier" {
+			name = strings.TrimSpace(c.Content(e.src))
+		}
+	}
+	if name == "" {
+		// Fall back to the composite-callee shape (dot_index_expression etc.).
+		name = extractCallName(first, e.src, e.lang)
+	}
+	if name == "" {
+		return symbols.Ref{}, false
+	}
+	return symbols.Ref{
+		Name:     name,
+		Line:     int(node.StartPoint().Row) + 1,
+		Language: e.lang,
+		Kind:     symbols.RefKindCall,
+	}, true
+}
+
+// --- Bash ---
+//
+// Grammar refs (tree-sitter-bash):
+//   function_definition        → "foo() { ... }" / "function foo { ... }"
+//                                `name` field holds a `word` identifier.
+//   command                    → command_name + argument words. `source x.sh`
+//                                and `. x.sh` are both commands; treat as
+//                                imports. Other commands emit a call ref.
+//   variable_assignment        → handled generically; we skip it here.
+//   declaration_command        → local/readonly/declare — not classified as
+//                                a top-level symbol.
+
+func (e *symbolExtractor) classifyBash(nodeType string, node *sitter.Node) (string, *sitter.Node) {
+	if nodeType != "function_definition" {
+		return "", nil
+	}
+	// `name` field is a word node with the function identifier.
+	if name := node.ChildByFieldName("name"); name != nil {
+		return "function", name
+	}
+	return "", nil
+}
+
+func (e *symbolExtractor) extractImportBash(nodeType string, node *sitter.Node) (symbols.Import, bool) {
+	if nodeType != "command" {
+		return symbols.Import{}, false
+	}
+	cn := findChildByType(node, "command_name")
+	if cn == nil {
+		return symbols.Import{}, false
+	}
+	cmd := strings.TrimSpace(cn.Content(e.src))
+	if cmd != "source" && cmd != "." {
+		return symbols.Import{}, false
+	}
+	// First `word` after the command_name is the path being sourced.
+	seenCmd := false
+	for i := 0; i < int(node.ChildCount()); i++ {
+		c := node.Child(i)
+		if !seenCmd {
+			if c == cn {
+				seenCmd = true
+			}
+			continue
+		}
+		if c.Type() == "word" || c.Type() == "string" || c.Type() == "raw_string" {
+			raw := strings.TrimSpace(c.Content(e.src))
+			// Strip surrounding quotes if present.
+			if len(raw) >= 2 {
+				if (raw[0] == '"' && raw[len(raw)-1] == '"') ||
+					(raw[0] == '\'' && raw[len(raw)-1] == '\'') {
+					raw = raw[1 : len(raw)-1]
+				}
+			}
+			if raw == "" {
+				continue
+			}
+			return symbols.Import{RawPath: raw, Language: e.lang}, true
+		}
+	}
+	return symbols.Import{}, false
+}
+
+func (e *symbolExtractor) extractRefBash(nodeType string, node *sitter.Node) (symbols.Ref, bool) {
+	if nodeType != "command" {
+		return symbols.Ref{}, false
+	}
+	cn := findChildByType(node, "command_name")
+	if cn == nil {
+		return symbols.Ref{}, false
+	}
+	name := strings.TrimSpace(cn.Content(e.src))
+	if name == "" {
+		return symbols.Ref{}, false
+	}
+	// source/. are imports, not call refs. A minimal ignore list avoids noise
+	// from shell builtins that dominate real scripts.
+	switch name {
+	case "source", ".", "set", "export", "readonly", "local", "declare",
+		"unset", "shift", "return", "break", "continue", "exit",
+		"if", "elif", "else", "fi", "then", "do", "done", "case", "esac",
+		"for", "while", "until", "[", "[[", "true", "false", ":":
+		return symbols.Ref{}, false
+	}
+	return symbols.Ref{
+		Name:     name,
+		Line:     int(node.StartPoint().Row) + 1,
+		Language: e.lang,
+		Kind:     symbols.RefKindCall,
+	}, true
 }
 
 func (e *symbolExtractor) classifyGeneric(nodeType string, node *sitter.Node) (string, *sitter.Node) {

--- a/parser/parser_feature_test.go
+++ b/parser/parser_feature_test.go
@@ -1969,3 +1969,383 @@ func TestFeatureJSNewExpressionMemberRef(t *testing.T) {
 		t.Fatal("expected to find Server ref from new member expression")
 	}
 }
+
+// --- C# Feature Tests ---
+
+func TestFeatureCSharpSymbols(t *testing.T) {
+	src := []byte(`using System;
+using System.Collections.Generic;
+using static System.Math;
+
+namespace MyApp.Core
+{
+    public interface IGreeter
+    {
+        string Greet(string name);
+    }
+
+    public class Greeter : IGreeter
+    {
+        private readonly string _prefix;
+
+        public Greeter(string prefix)
+        {
+            _prefix = prefix;
+        }
+
+        public string Greet(string name)
+        {
+            return _prefix + ", " + name;
+        }
+    }
+
+    public struct Point
+    {
+        public int X { get; }
+    }
+
+    public enum Color { Red, Green, Blue }
+
+    public record User(string Name, int Age);
+}
+`)
+	result, err := ParseSource(src, "test.cs", "csharp", lang.Default.TreeSitter("csharp"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name, kind string
+	}{
+		{"MyApp.Core", "namespace"},
+		{"IGreeter", "interface"},
+		{"Greeter", "class"},
+		{"Greet", "method"},
+		{"Point", "struct"},
+		{"Color", "enum"},
+		{"User", "record"},
+	}
+	for _, c := range cases {
+		if findSymbolKind(result.Symbols, c.name, c.kind) == nil {
+			debugParseResult(t, result)
+			t.Fatalf("expected %s %q", c.kind, c.name)
+		}
+	}
+
+	// Constructor
+	if findSymbolKind(result.Symbols, "Greeter", "constructor") == nil {
+		debugParseResult(t, result)
+		t.Fatal("expected constructor Greeter")
+	}
+	// Property
+	if findSymbolKind(result.Symbols, "X", "property") == nil {
+		debugParseResult(t, result)
+		t.Fatal("expected property X")
+	}
+}
+
+func TestFeatureCSharpImports(t *testing.T) {
+	src := []byte(`using System;
+using System.Collections.Generic;
+using static System.Math;
+using Alias = System.IO.Path;
+`)
+	result, err := ParseSource(src, "test.cs", "csharp", lang.Default.TreeSitter("csharp"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, want := range []string{"System", "System.Collections.Generic", "System.Math"} {
+		if findImport(result.Imports, want) == nil {
+			debugParseResult(t, result)
+			t.Fatalf("expected using %q", want)
+		}
+	}
+}
+
+func TestFeatureCSharpRefs(t *testing.T) {
+	src := []byte(`using System;
+
+class Program
+{
+    static void Main()
+    {
+        var g = new Greeter("Hi");
+        Console.WriteLine(g.Greet("world"));
+    }
+}
+`)
+	result, err := ParseSource(src, "test.cs", "csharp", lang.Default.TreeSitter("csharp"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, want := range []string{"Greeter", "WriteLine", "Greet"} {
+		if findRef(result.Refs, want) == nil {
+			debugParseResult(t, result)
+			t.Fatalf("expected ref %q", want)
+		}
+	}
+}
+
+// --- PHP Feature Tests ---
+
+func TestFeaturePHPSymbols(t *testing.T) {
+	src := []byte(`<?php
+namespace App\Service;
+
+interface Greeter {
+    public function greet(string $name): string;
+}
+
+trait Loggable {
+    public function log(string $msg): void {}
+}
+
+class DefaultGreeter implements Greeter
+{
+    use Loggable;
+
+    public function __construct(string $prefix) {}
+
+    public function greet(string $name): string {
+        return $prefix . ', ' . $name;
+    }
+}
+
+enum Color {
+    case Red;
+    case Green;
+}
+
+function make_greeter(string $p): Greeter {
+    return new DefaultGreeter($p);
+}
+`)
+	result, err := ParseSource(src, "test.php", "php", lang.Default.TreeSitter("php"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name, kind string
+	}{
+		{"Greeter", "interface"},
+		{"Loggable", "trait"},
+		{"DefaultGreeter", "class"},
+		{"Color", "enum"},
+		{"make_greeter", "function"},
+		{"greet", "method"},
+		{"__construct", "method"},
+	}
+	for _, c := range cases {
+		if findSymbolKind(result.Symbols, c.name, c.kind) == nil {
+			debugParseResult(t, result)
+			t.Fatalf("expected %s %q", c.kind, c.name)
+		}
+	}
+}
+
+func TestFeaturePHPImports(t *testing.T) {
+	src := []byte(`<?php
+namespace App\Service;
+
+use App\Model\User;
+use App\Repo\UserRepo as Repo;
+use Psr\Log\LoggerInterface;
+`)
+	result, err := ParseSource(src, "test.php", "php", lang.Default.TreeSitter("php"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, want := range []string{"App\\Model\\User", "App\\Repo\\UserRepo", "Psr\\Log\\LoggerInterface"} {
+		if findImport(result.Imports, want) == nil {
+			debugParseResult(t, result)
+			t.Fatalf("expected use %q", want)
+		}
+	}
+}
+
+func TestFeaturePHPRefs(t *testing.T) {
+	src := []byte(`<?php
+function run() {
+    $g = make_greeter('Hi');
+    $g->greet('world');
+    Logger::info('ok');
+    $x = new DefaultGreeter('p');
+}
+`)
+	result, err := ParseSource(src, "test.php", "php", lang.Default.TreeSitter("php"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, want := range []string{"make_greeter", "greet", "info", "DefaultGreeter"} {
+		if findRef(result.Refs, want) == nil {
+			debugParseResult(t, result)
+			t.Fatalf("expected ref %q", want)
+		}
+	}
+}
+
+// --- Lua Feature Tests ---
+
+func TestFeatureLuaSymbols(t *testing.T) {
+	src := []byte(`local M = {}
+
+function M.greet(name)
+    return "Hello, " .. name
+end
+
+local function helper(x)
+    return x * 2
+end
+
+function M:new(opts)
+    return opts
+end
+
+return M
+`)
+	result, err := ParseSource(src, "test.lua", "lua", lang.Default.TreeSitter("lua"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if findSymbolKind(result.Symbols, "greet", "function") == nil {
+		debugParseResult(t, result)
+		t.Fatal("expected function greet")
+	}
+	if findSymbolKind(result.Symbols, "helper", "function") == nil {
+		debugParseResult(t, result)
+		t.Fatal("expected function helper")
+	}
+	if findSymbolKind(result.Symbols, "new", "method") == nil {
+		debugParseResult(t, result)
+		t.Fatal("expected method new (M:new)")
+	}
+}
+
+func TestFeatureLuaImports(t *testing.T) {
+	src := []byte(`local util = require("util")
+local http = require "http"
+local json = require('json')
+`)
+	result, err := ParseSource(src, "test.lua", "lua", lang.Default.TreeSitter("lua"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, want := range []string{"util", "http", "json"} {
+		if findImport(result.Imports, want) == nil {
+			debugParseResult(t, result)
+			t.Fatalf("expected require %q", want)
+		}
+	}
+}
+
+func TestFeatureLuaRefs(t *testing.T) {
+	src := []byte(`local util = require("util")
+
+util.debug("ok")
+helper(21)
+M:new({})
+`)
+	result, err := ParseSource(src, "test.lua", "lua", lang.Default.TreeSitter("lua"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, want := range []string{"debug", "helper", "new"} {
+		if findRef(result.Refs, want) == nil {
+			debugParseResult(t, result)
+			t.Fatalf("expected ref %q", want)
+		}
+	}
+	// require should not emit a call ref (it's an import)
+	if findRef(result.Refs, "require") != nil {
+		debugParseResult(t, result)
+		t.Fatal("require should be an import, not a ref")
+	}
+}
+
+// --- Bash Feature Tests ---
+
+func TestFeatureBashSymbols(t *testing.T) {
+	src := []byte(`#!/usr/bin/env bash
+
+function greet() {
+  local name="$1"
+  echo "hello, $name"
+}
+
+run_task() {
+  greet "$1"
+}
+`)
+	result, err := ParseSource(src, "test.sh", "bash", lang.Default.TreeSitter("bash"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, want := range []string{"greet", "run_task"} {
+		if findSymbolKind(result.Symbols, want, "function") == nil {
+			debugParseResult(t, result)
+			t.Fatalf("expected function %q", want)
+		}
+	}
+}
+
+func TestFeatureBashImports(t *testing.T) {
+	src := []byte(`#!/usr/bin/env bash
+source ./lib/common.sh
+. ./lib/util.sh
+source "./lib/quoted.sh"
+`)
+	result, err := ParseSource(src, "test.sh", "bash", lang.Default.TreeSitter("bash"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, want := range []string{"./lib/common.sh", "./lib/util.sh", "./lib/quoted.sh"} {
+		if findImport(result.Imports, want) == nil {
+			debugParseResult(t, result)
+			t.Fatalf("expected source %q", want)
+		}
+	}
+}
+
+func TestFeatureBashRefs(t *testing.T) {
+	src := []byte(`#!/usr/bin/env bash
+
+run_task() {
+  greet "$1"
+  deploy "$1" || rollback
+}
+
+run_task "world"
+`)
+	result, err := ParseSource(src, "test.sh", "bash", lang.Default.TreeSitter("bash"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, want := range []string{"greet", "deploy", "rollback", "run_task"} {
+		if findRef(result.Refs, want) == nil {
+			debugParseResult(t, result)
+			t.Fatalf("expected ref %q", want)
+		}
+	}
+	// shell builtins should not appear as refs
+	for _, skip := range []string{"source", ".", "local", "echo"} {
+		// echo isn't in our ignore list, but source/./local are — verify those.
+		if skip == "echo" {
+			continue
+		}
+		if findRef(result.Refs, skip) != nil {
+			debugParseResult(t, result)
+			t.Fatalf("shell builtin %q should not appear as a ref", skip)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #22 phase 1 + 2. Four languages (C#, PHP, Lua, Bash) were parseable by tree-sitter but falling through to `classifyGeneric`, leaving them with missing symbol kinds and empty import/ref graphs. Each now has proper `classify` / `extractImport` / `extractRef` paths.

- **C#** — namespace/class/struct/interface/enum/record/delegate/method/constructor/destructor/property/field/enum_member; `using` / `using static` imports; `invocation_expression` and `object_creation_expression` refs.
- **PHP** — namespace/class/interface/trait/enum/function/method/const_element/enum_case; `namespace_use_declaration` imports; function/member/scoped/nullsafe calls plus `new` refs.
- **Lua** — function/method symbols from `function_statement` (handles `M.foo` and `M:new`); `require("x")` / `require "x"` / `require 'x'` imports; call refs that handle the flat dot/colon shapes tree-sitter-lua emits.
- **Bash** — `function_definition` symbols; `source` / `.` imports; command-invocation refs with a small ignore list for shell builtins / control-flow keywords.

**Scope notes:**
- YAML intentionally stays on the generic path — no functions, imports, or calls to extract. Noted in the CHANGELOG.
- Swift was listed in #22 but already had dedicated coverage before this PR.

**Impact on open PRs:** this directly improves `cymbal refs` accuracy and cuts false positives in PR #17 (`dead`) and PR #18 (`depends`) when those run against C#/PHP/Lua/Bash projects.

## Testing

- `parser_feature_test.go` gains 12 new tests (3 per language × 4 languages) covering symbols, imports, and refs.
- `CGO_CFLAGS="-DSQLITE_ENABLE_FTS5" go test ./...` — all packages pass.

## Risks / Rollout

- Risk: low — purely additive language paths, no changes to existing classifiers. Dispatch switches fall through to `classifyGeneric` / `return false` as before for any shape not explicitly handled.
- Rollback: revert the commit; no schema or API changes.
