### PR TITLE
fix(parser): index underscore-prefixed Python functions

### DIFF
--- a/parser/parser.go
+++ b/parser/parser.go
@@ -681,14 +681,12 @@ func (e *symbolExtractor) classifyPython(nodeType string, node *sitter.Node) (st
 		if node.Parent() != nil && node.Parent().Type() == "decorated_definition" {
 			return "", nil
 		}
-		nameNode := node.ChildByFieldName("name")
-		if nameNode != nil {
-			name := nameNode.Content(e.src)
-			if len(name) > 0 && name[0] == '_' && name != "__init__" {
-				return "", nil
-			}
-		}
-		return "function", nameNode
+		// Underscore-prefixed Python functions are *module-internal*, not
+		// unimportant: many codebases put the bulk of their logic behind
+		// leading-underscore helpers. Dropping them from the index broke
+		// trace/impact/refs/investigate for any call chain through a
+		// private function (issue 41). Index them like any other function.
+		return "function", node.ChildByFieldName("name")
 	case "class_definition":
 		// Skip if parent is decorated_definition — the parent already emits this symbol.
 		if node.Parent() != nil && node.Parent().Type() == "decorated_definition" {
@@ -712,14 +710,10 @@ func (e *symbolExtractor) classifyPython(nodeType string, node *sitter.Node) (st
 func (e *symbolExtractor) classifyPythonInner(nodeType string, node *sitter.Node) (string, *sitter.Node) {
 	switch nodeType {
 	case "function_definition":
-		nameNode := node.ChildByFieldName("name")
-		if nameNode != nil {
-			name := nameNode.Content(e.src)
-			if len(name) > 0 && name[0] == '_' && name != "__init__" {
-				return "", nil
-			}
-		}
-		return "function", nameNode
+		// Mirror classifyPython: underscore-prefixed Python functions
+		// are module-internal, not unimportant; index them like any
+		// other function so decorated helpers remain discoverable.
+		return "function", node.ChildByFieldName("name")
 	case "class_definition":
 		return "class", node.ChildByFieldName("name")
 	}

--- a/parser/parser_feature_test.go
+++ b/parser/parser_feature_test.go
@@ -365,7 +365,10 @@ class Dog(Animal):
 	}
 }
 
-func TestFeaturePythonPrivateSkipped(t *testing.T) {
+// TestFeaturePythonPrivateIndexed guards issue #41: underscore-prefixed
+// Python functions are module-internal, not unimportant, and must be
+// indexed so trace/impact/refs/investigate still work through them.
+func TestFeaturePythonPrivateIndexed(t *testing.T) {
 	src := []byte(`def public_func():
     pass
 
@@ -380,19 +383,10 @@ def __very_private():
 		t.Fatal(err)
 	}
 
-	pub := findSymbol(result.Symbols, "public_func")
-	if pub == nil {
-		t.Fatal("expected to find public_func")
-	}
-
-	priv := findSymbol(result.Symbols, "_private_func")
-	if priv != nil {
-		t.Error("expected _private_func to be skipped")
-	}
-
-	vpriv := findSymbol(result.Symbols, "__very_private")
-	if vpriv != nil {
-		t.Error("expected __very_private to be skipped")
+	for _, name := range []string{"public_func", "_private_func", "__very_private"} {
+		if findSymbol(result.Symbols, name) == nil {
+			t.Errorf("expected to find %s in parsed symbols", name)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes 1broseidon/cymbal#41.

`classifyPython` / `classifyPythonInner` skipped every `function_definition` whose name started with `_` (except `__init__`). Python's leading underscore denotes *module-internal* scope, not unimportance — many codebases put the bulk of their logic behind `_helpers` and reserve bare names for public entry points. Dropping them from the index broke `trace`, `impact`, `refs`, and `investigate` for any call chain through a private function (the reporter's project had 79/81 functions underscore-prefixed).

## Fix

Drop the skip in both `classifyPython` and `classifyPythonInner` (matches Option 1 in the issue).

The existing `TestFeaturePythonPrivateSkipped` is renamed to `TestFeaturePythonPrivateIndexed` and updated to assert the new inclusive behaviour.

## Test plan

- [x] `go test ./parser/...` passes locally.