### PR TITLE
[codex] Add Codecov coverage upload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,15 @@ jobs:
           cache: true
 
       - name: Test
-        run: make test
+        run: make test-coverage
+
+      - name: Upload coverage reports to Codecov
+        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: coverage.txt
+          fail_ci_if_error: true
 
   security:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ Thumbs.db
 
 # Go
 /vendor/
+/coverage.txt
 
 # Docs
 docs/node_modules/

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,10 @@ COMMIT  ?= $(shell git rev-parse HEAD 2>/dev/null || echo unknown)
 DATE    ?= $(shell date -u +%Y-%m-%dT%H:%M:%SZ)
 VERSION_PKG := github.com/1broseidon/cymbal/cmd
 LDFLAGS := -X $(VERSION_PKG).version=v0.12.1 -X $(VERSION_PKG).commit=$(COMMIT) -X $(VERSION_PKG).date=$(DATE)
+MODULE := $(shell go list -m)
+COVER_PACKAGES := $(shell git ls-files '*.go' | while read file; do dirname "$$file"; done | sort -u | while read dir; do go list "./$$dir"; done | grep -v '^$(MODULE)$$')
 
-.PHONY: build build-check ci clean install lint test vulncheck
+.PHONY: build build-check ci clean install lint test test-coverage vulncheck
 
 build:
 	CGO_CFLAGS="$(CGO_CFLAGS)" go build -ldflags "$(LDFLAGS)" -o $(BINARY) .
@@ -21,6 +23,9 @@ install:
 test:
 	CGO_CFLAGS="$(CGO_CFLAGS)" go test ./...
 
+test-coverage:
+	CGO_CFLAGS="$(CGO_CFLAGS)" go test -covermode=atomic -coverprofile=coverage.txt $(COVER_PACKAGES)
+
 lint:
 	go vet ./...
 
@@ -30,4 +35,4 @@ vulncheck:
 ci: build-check lint test vulncheck
 
 clean:
-	rm -f $(BINARY)
+	rm -f $(BINARY) coverage.txt

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![GitHub Stars](https://img.shields.io/github/stars/1broseidon/cymbal?style=social)](https://github.com/1broseidon/cymbal/stargazers)
 [![Go Reference](https://pkg.go.dev/badge/github.com/1broseidon/cymbal.svg)](https://pkg.go.dev/github.com/1broseidon/cymbal)
 [![Go Report Card](https://goreportcard.com/badge/github.com/1broseidon/cymbal)](https://goreportcard.com/report/github.com/1broseidon/cymbal)
+[![codecov](https://codecov.io/gh/1broseidon/cymbal/branch/main/graph/badge.svg)](https://codecov.io/gh/1broseidon/cymbal)
 [![Latest Release](https://img.shields.io/github/v/release/1broseidon/cymbal)](https://github.com/1broseidon/cymbal/releases/latest)
 
 cymbal is a fast, language-agnostic code navigator. It parses your codebase


### PR DESCRIPTION
## Summary
- add a `test-coverage` Makefile target that writes `coverage.txt`
- upload coverage from the CI test job with `codecov/codecov-action@v5`
- add a Codecov badge/link to the README and ignore generated coverage output locally

## Validation
- `make test-coverage`
- `go tool cover -func=coverage.txt`
