### PR TITLE
Add first-class OpenCode hook installer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,6 +51,13 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+
+      - name: Validate OpenCode plugin asset syntax
+        run: node --check cmd/hook_assets/opencode/cymbal-opencode.js
+
       - name: Test
         run: make test-coverage
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to cymbal are documented here.
 
 - **Regression coverage now reaches the 80% product target** — coverage excludes the internal `bench/` evaluation harness from the product denominator and now covers parser/walker behavior, command-facing workflows, public index facade APIs, diff output, and update-notifier state transitions. `CGO_CFLAGS="-DSQLITE_ENABLE_FTS5" make test-coverage` reports 80%+ total product coverage.
 - **Codecov now uses the same product coverage denominator as CI** — CI converts Go's block coverprofile into LCOV line hits before upload, `codecov.yml` ignores the internal bench harness plus non-executable test, entrypoint, type, and registry files, and command entrypoint regression tests keep Codecov's line-oriented calculation above the threshold.
+- **OpenCode now has a first-class installer path** — `cymbal hook install opencode` installs a cymbal-managed OpenCode plugin in the documented plugin directory for user or project scope, making OpenCode the main supported cymbal integration path instead of relying on `AGENTS.md` bootstrap text. The managed plugin refreshes guidance through `cymbal hook remind --update=if-stale`, so update guidance stays fresh automatically while cymbal still never self-updates by default.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -288,8 +288,8 @@ Cymbal is designed to be an agent's code navigation layer, but the README only
 summarizes the integration story. The full install snippets and hook wiring
 live in the dedicated docs:
 
-- [docs/AGENT_HOOKS.md](docs/AGENT_HOOKS.md) — Claude Code install, `nudge`,
-  `remind`, and snippets for other agent runtimes
+- [docs/AGENT_HOOKS.md](docs/AGENT_HOOKS.md) — OpenCode and Claude Code install,
+  `nudge`, `remind`, and snippets for other agent runtimes
 - [docs/guide/agent-native.md](docs/guide/agent-native.md) — frontmatter output
   format and why it is cheaper than JSON by default
 
@@ -304,7 +304,20 @@ If you are writing agent instructions, the short policy is:
 - Use `cymbal search --text <pattern> [path ...]` for scoped literal or regex searches
 - Add `--graph` when the agent needs topology, not call-site text
 
-Claude Code has a one-line installer:
+OpenCode has a one-line installer:
+
+```sh
+cymbal hook install opencode
+```
+
+This installs a cymbal-managed OpenCode plugin under the documented plugin
+directory for the chosen scope. The plugin refreshes session guidance via
+`cymbal hook remind --update=if-stale` and soft-nudges bash grep/find/fd usage
+back toward cymbal-first navigation on non-Windows shells. Reminder/update guidance stays fresh
+without editing `AGENTS.md`. Cymbal still never self-updates by default; it
+only tells the agent or user which explicit update command to run.
+
+Claude Code also has a one-line installer:
 
 ```sh
 cymbal hook install claude-code

--- a/cmd/cli_codecov_test.go
+++ b/cmd/cli_codecov_test.go
@@ -127,6 +127,7 @@ func newLsTestCommand(dbPath string) *cobra.Command {
 
 func TestCodecovCLIIndexRunERegressions(t *testing.T) {
 	repo := t.TempDir()
+	t.Cleanup(index.CloseAll)
 	t.Setenv("CYMBAL_CACHE_DIR", t.TempDir())
 	writeFile(t, repo, "go.mod", "module example.com/indexrun\n\ngo 1.25\n")
 	writeFile(t, repo, "main.go", `package main
@@ -571,6 +572,7 @@ func TestCodecovCLIOutlineLsInvestigateRunEModes(t *testing.T) {
 }
 
 func TestCodecovCLIRootDiffVersionUpdateRegressions(t *testing.T) {
+	t.Cleanup(index.CloseAll)
 	repo, dbPath := newPhase2Repo(t)
 
 	flagCmd := commandWithDB(dbPath)

--- a/cmd/cli_phase2_test.go
+++ b/cmd/cli_phase2_test.go
@@ -664,7 +664,7 @@ func TestPhase3CommandOutputFiltersUpdateAndVersion(t *testing.T) {
 	}
 	if err := os.WriteFile(filepath.Join(updateDir, "update-check.json"), []byte(`{
   "schema_version": 1,
-  "last_checked_at": "2026-04-24T10:00:00Z",
+  "last_checked_at": "2099-04-24T10:00:00Z",
   "latest_version": "v9.9.9",
   "release_url": "https://example.test/release",
   "update_available": true,

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -108,11 +109,12 @@ Update checks:
 
 var hookInstallCmd = &cobra.Command{
 	Use:   "install <agent>",
-	Short: "Install cymbal hooks into the given agent (claude-code)",
+	Short: "Install cymbal hooks into the given agent (claude-code, opencode)",
 	Long: `Wire the nudge and remind hooks into the named agent's config.
 
 Supported agents:
-  claude-code   ~/.claude/settings.json (or --scope project for .claude/settings.json)
+	  claude-code   ~/.claude/settings.json (or --scope project for .claude/settings.json)
+	  opencode      ~/.config/opencode/plugins/cymbal-opencode.js (or --scope project for .opencode/plugins/cymbal-opencode.js)
 
 For other agents (Cursor, Windsurf, aider, Cline, Continue, Zed, ...), see
 docs/AGENT_HOOKS.md for copy-paste snippets that wire 'cymbal hook nudge'
@@ -590,8 +592,10 @@ func lookupHookAdapter(name string) (hookAdapter, error) {
 	switch strings.ToLower(name) {
 	case "claude-code", "claudecode", "claude":
 		return hookAdapter{install: installClaudeCode, uninstall: uninstallClaudeCode}, nil
+	case "opencode":
+		return hookAdapter{install: installOpenCode, uninstall: uninstallOpenCode}, nil
 	}
-	return hookAdapter{}, fmt.Errorf("unknown agent %q (supported: claude-code). "+
+	return hookAdapter{}, fmt.Errorf("unknown agent %q (supported: claude-code, opencode). "+
 		"For other agents see docs/AGENT_HOOKS.md — 'cymbal hook nudge' and "+
 		"'cymbal hook remind' can be wired by hand into any agent's hook point.", name)
 }
@@ -822,4 +826,189 @@ func uninstallClaudeCode(scope string, dryRun bool) (string, string, error) {
 		return path, "", err
 	}
 	return path, string(data), nil
+}
+
+// ── OpenCode adapter ──
+
+const (
+	opencodeManagedPluginFile = "cymbal-opencode.js"
+	opencodeHookMarker        = "cymbal-hook"
+)
+
+const opencodeManagedHeaderPrefix = "// " + opencodeHookMarker + " managed by cymbal\n// cymbal-version: "
+
+func opencodePluginPath(scope string) (string, error) {
+	if scope == "project" {
+		return filepath.Join(".opencode", "plugins", opencodeManagedPluginFile), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".config", "opencode", "plugins", opencodeManagedPluginFile), nil
+}
+
+func opencodePluginContents() string {
+	return renderOpenCodePlugin(opencodeHookMarker, currentVersion())
+}
+
+func writeManagedFile(path, content string) error {
+	if managed, err := openCodeManagedFileState(path); err != nil {
+		return err
+	} else if !managed {
+		return fmt.Errorf("refusing to overwrite non-cymbal OpenCode plugin at %s", path)
+	}
+	if err := ensureSafeManagedTarget(path); err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	mode := os.FileMode(0o644)
+	if info, err := os.Stat(path); err == nil {
+		mode = info.Mode().Perm()
+	}
+	return atomicWriteFile(path, []byte(content), mode)
+}
+
+func installOpenCode(scope string, dryRun bool) (string, string, error) {
+	path, err := opencodePluginPath(scope)
+	if err != nil {
+		return "", "", err
+	}
+	otherScope := "user"
+	if scope == "user" {
+		otherScope = "project"
+	}
+	otherPath, err := opencodePluginPath(otherScope)
+	if err != nil {
+		return path, "", err
+	}
+	otherManaged, err := opencodeManagedFileExists(otherPath)
+	if err != nil {
+		return path, "", err
+	}
+	if otherManaged {
+		return path, "", fmt.Errorf("cymbal-managed OpenCode plugin already exists in %s scope at %s; uninstall it before installing %s scope", otherScope, otherPath, scope)
+	}
+	managed, err := openCodeManagedFileState(path)
+	if err != nil {
+		return path, "", err
+	}
+	content := opencodePluginContents()
+	if dryRun {
+		if !managed {
+			return path, "", fmt.Errorf("would refuse to overwrite non-cymbal OpenCode plugin at %s", path)
+		}
+		return path, content, nil
+	}
+	if err := writeManagedFile(path, content); err != nil {
+		return path, "", err
+	}
+	return path, content, nil
+}
+
+func uninstallOpenCode(scope string, dryRun bool) (string, string, error) {
+	path, err := opencodePluginPath(scope)
+	if err != nil {
+		return "", "", err
+	}
+	managed, err := openCodeManagedFileState(path)
+	if err != nil {
+		return path, "", err
+	}
+	if dryRun {
+		if !managed {
+			return path, "leave non-cymbal OpenCode plugin untouched", nil
+		}
+		return path, "remove managed OpenCode plugin", nil
+	}
+	if !managed {
+		return path, "leave non-cymbal OpenCode plugin untouched", nil
+	}
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return path, "", err
+	}
+	return path, "remove managed OpenCode plugin", nil
+}
+
+func openCodeManagedFileState(path string) (bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return true, nil
+		}
+		return false, err
+	}
+	return strings.HasPrefix(string(data), opencodeManagedHeaderPrefix), nil
+}
+
+func opencodeManagedFileExists(path string) (bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return false, nil
+		}
+		return false, err
+	}
+	return strings.HasPrefix(string(data), opencodeManagedHeaderPrefix), nil
+}
+
+func atomicWriteFile(path string, data []byte, mode os.FileMode) error {
+	dir := filepath.Dir(path)
+	tmpFile, err := os.CreateTemp(dir, filepath.Base(path)+".*.tmp")
+	if err != nil {
+		return err
+	}
+	tmp := tmpFile.Name()
+	if _, err := tmpFile.Write(data); err != nil {
+		_ = tmpFile.Close()
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := tmpFile.Close(); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := os.Chmod(tmp, mode); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return os.Chmod(path, mode)
+}
+
+func ensureSafeManagedTarget(path string) error {
+	if info, err := os.Lstat(path); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to write through symlinked OpenCode plugin path %s", path)
+		}
+	} else if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+
+	for dir := filepath.Dir(path); dir != ""; dir = filepath.Dir(dir) {
+		info, err := os.Lstat(dir)
+		if errors.Is(err, os.ErrNotExist) {
+			next := filepath.Dir(dir)
+			if next == dir {
+				break
+			}
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("refusing to write inside symlinked OpenCode plugin directory %s", dir)
+		}
+		next := filepath.Dir(dir)
+		if next == dir {
+			break
+		}
+	}
+	return nil
 }

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -114,7 +114,7 @@ var hookInstallCmd = &cobra.Command{
 
 Supported agents:
 	  claude-code   ~/.claude/settings.json (or --scope project for .claude/settings.json)
-	  opencode      ~/.config/opencode/plugins/cymbal-opencode.js (or --scope project for .opencode/plugins/cymbal-opencode.js)
+	  opencode      <user-config-dir>/opencode/plugins/cymbal-opencode.js (or --scope project for .opencode/plugins/cymbal-opencode.js)
 
 For other agents (Cursor, Windsurf, aider, Cline, Continue, Zed, ...), see
 docs/AGENT_HOOKS.md for copy-paste snippets that wire 'cymbal hook nudge'
@@ -841,11 +841,11 @@ func opencodePluginPath(scope string) (string, error) {
 	if scope == "project" {
 		return filepath.Join(".opencode", "plugins", opencodeManagedPluginFile), nil
 	}
-	home, err := os.UserHomeDir()
+	configRoot, err := os.UserConfigDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(home, ".config", "opencode", "plugins", opencodeManagedPluginFile), nil
+	return filepath.Join(configRoot, "opencode", "plugins", opencodeManagedPluginFile), nil
 }
 
 func opencodePluginContents() string {

--- a/cmd/hook_assets/opencode/cymbal-opencode.js
+++ b/cmd/hook_assets/opencode/cymbal-opencode.js
@@ -1,0 +1,37 @@
+export default async ({ $ }) => ({
+  "experimental.chat.system.transform": async (_input, output) => {
+    try {
+      const reminder = await $`cymbal hook remind --format=text --update=if-stale`.text()
+      const text = reminder.trim()
+      if (text) output.system.push(text)
+    } catch (error) {
+      void error
+    }
+  },
+  "tool.execute.before": async (input, output) => {
+    if (input.tool !== "bash") return
+    if (!output.args || typeof output.args.command !== "string") return
+
+    if (process.platform === "win32") return
+
+    try {
+      const payload = new Response(
+        JSON.stringify({
+          tool_name: "bash",
+          tool_input: { command: output.args.command },
+        }),
+      )
+      const raw = await $`cymbal hook nudge --format=json < ${payload}`.quiet().nothrow().text()
+      const text = raw.trim()
+      if (!text) return
+
+      const result = JSON.parse(text)
+      if (typeof result.suggest !== "string" || typeof result.why !== "string") return
+
+      const notice = `cymbal nudge: ${result.suggest} — ${result.why}`.replaceAll("'", `'"'"'`)
+      output.args.command = `printf '%s\n' '${notice}' >&2; ${output.args.command}`
+    } catch (error) {
+      void error
+    }
+  },
+})

--- a/cmd/hook_assets_opencode.go
+++ b/cmd/hook_assets_opencode.go
@@ -1,0 +1,22 @@
+package cmd
+
+import (
+	"embed"
+	"fmt"
+	"strings"
+)
+
+//go:embed hook_assets/opencode/cymbal-opencode.js
+var opencodeHookAssets embed.FS
+
+func renderOpenCodePlugin(marker, version string) string {
+	body, err := opencodeHookAssets.ReadFile("hook_assets/opencode/cymbal-opencode.js")
+	if err != nil {
+		panic(fmt.Errorf("read embedded OpenCode plugin asset: %w", err))
+	}
+	content := string(body)
+	if !strings.HasSuffix(content, "\n") {
+		content += "\n"
+	}
+	return fmt.Sprintf("// %s managed by cymbal\n// cymbal-version: %s\n%s", marker, version, content)
+}

--- a/cmd/hook_test.go
+++ b/cmd/hook_test.go
@@ -613,10 +613,13 @@ func TestOpenCodeInstallProjectScopeWritesManagedPlugin(t *testing.T) {
 
 func TestOpenCodeInstallUserScopeWritesManagedPlugin(t *testing.T) {
 	home := t.TempDir()
+	configRoot := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("USERPROFILE", home)
 	t.Setenv("HOMEDRIVE", "")
 	t.Setenv("HOMEPATH", "")
+	t.Setenv("XDG_CONFIG_HOME", configRoot)
+	t.Setenv("APPDATA", configRoot)
 
 	adapter, err := lookupHookAdapter("opencode")
 	if err != nil {
@@ -627,7 +630,11 @@ func TestOpenCodeInstallUserScopeWritesManagedPlugin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("install failed: %v", err)
 	}
-	wantTarget := filepath.Join(home, ".config", "opencode", "plugins", "cymbal-opencode.js")
+	resolvedConfigRoot, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	wantTarget := filepath.Join(resolvedConfigRoot, "opencode", "plugins", "cymbal-opencode.js")
 	if target != wantTarget {
 		t.Fatalf("unexpected user target: got %q want %q", target, wantTarget)
 	}

--- a/cmd/hook_test.go
+++ b/cmd/hook_test.go
@@ -564,3 +564,360 @@ func TestLookupHookAdapterUnknownAgentMentionsDocs(t *testing.T) {
 		t.Errorf("unknown-agent error should point users at the docs; got %q", err)
 	}
 }
+
+func TestLookupHookAdapterOpenCode(t *testing.T) {
+	adapter, err := lookupHookAdapter("opencode")
+	if err != nil {
+		t.Fatalf("expected opencode adapter, got error: %v", err)
+	}
+	if adapter.install == nil || adapter.uninstall == nil {
+		t.Fatalf("expected non-nil install/uninstall funcs, got %+v", adapter)
+	}
+}
+
+func TestOpenCodeInstallProjectScopeWritesManagedPlugin(t *testing.T) {
+	dir := t.TempDir()
+	withTestWorkingDir(t, dir)
+
+	adapter, err := lookupHookAdapter("opencode")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	target, _, err := adapter.install("project", false)
+	if err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+	wantTarget := filepath.Join(".opencode", "plugins", "cymbal-opencode.js")
+	if target != wantTarget {
+		t.Fatalf("unexpected project target: got %q want %q", target, wantTarget)
+	}
+	absTarget := filepath.Join(dir, wantTarget)
+	data, err := os.ReadFile(absTarget)
+	if err != nil {
+		t.Fatalf("expected managed plugin file at %s: %v", absTarget, err)
+	}
+	if !strings.Contains(string(data), "cymbal hook remind") || !strings.Contains(string(data), "--update=if-stale") {
+		t.Fatalf("expected managed plugin to delegate to remind with stale-aware updates, got %q", string(data))
+	}
+	if !strings.Contains(string(data), `"tool.execute.before"`) || !strings.Contains(string(data), `cymbal hook nudge --format=json`) {
+		t.Fatalf("expected managed plugin to install OpenCode bash nudge hook, got %q", string(data))
+	}
+	if !strings.Contains(string(data), `tool_input: { command: output.args.command }`) || !strings.Contains(string(data), `process.platform === "win32"`) {
+		t.Fatalf("expected managed plugin to delegate structured nudge input and guard Windows shell rewriting, got %q", string(data))
+	}
+	if !strings.Contains(string(data), opencodeHookMarker) || !strings.Contains(string(data), currentVersion()) {
+		t.Fatalf("expected managed plugin metadata marker/version, got %q", string(data))
+	}
+}
+
+func TestOpenCodeInstallUserScopeWritesManagedPlugin(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("HOMEDRIVE", "")
+	t.Setenv("HOMEPATH", "")
+
+	adapter, err := lookupHookAdapter("opencode")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	target, _, err := adapter.install("user", false)
+	if err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+	wantTarget := filepath.Join(home, ".config", "opencode", "plugins", "cymbal-opencode.js")
+	if target != wantTarget {
+		t.Fatalf("unexpected user target: got %q want %q", target, wantTarget)
+	}
+	if _, err := os.Stat(wantTarget); err != nil {
+		t.Fatalf("expected managed plugin file at %s: %v", wantTarget, err)
+	}
+}
+
+func TestOpenCodeInstallDryRunDoesNotWrite(t *testing.T) {
+	dir := t.TempDir()
+	withTestWorkingDir(t, dir)
+
+	adapter, err := lookupHookAdapter("opencode")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	target, summary, err := adapter.install("project", true)
+	if err != nil {
+		t.Fatalf("dry-run install failed: %v", err)
+	}
+	wantTarget := filepath.Join(".opencode", "plugins", "cymbal-opencode.js")
+	if target != wantTarget {
+		t.Fatalf("unexpected project target: got %q want %q", target, wantTarget)
+	}
+	if _, err := os.Stat(filepath.Join(dir, wantTarget)); !os.IsNotExist(err) {
+		t.Fatalf("dry-run should not write managed plugin file; stat err=%v", err)
+	}
+	if !strings.Contains(summary, "cymbal hook remind") || !strings.Contains(summary, "--update=if-stale") {
+		t.Fatalf("dry-run summary should show stale-aware remind integration, got %q", summary)
+	}
+	if !strings.Contains(summary, `"tool.execute.before"`) || !strings.Contains(summary, `cymbal hook nudge --format=json`) {
+		t.Fatalf("dry-run summary should include bash nudge integration, got %q", summary)
+	}
+	if !strings.Contains(summary, opencodeHookMarker) || !strings.Contains(summary, currentVersion()) {
+		t.Fatalf("dry-run summary should include managed plugin metadata, got %q", summary)
+	}
+}
+
+func TestOpenCodeInstallIsIdempotentAndUninstallPreservesUnrelatedPlugins(t *testing.T) {
+	dir := t.TempDir()
+	withTestWorkingDir(t, dir)
+
+	pluginsDir := filepath.Join(dir, ".opencode", "plugins")
+	if err := os.MkdirAll(pluginsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	userPlugin := filepath.Join(pluginsDir, "user-owned.js")
+	if err := os.WriteFile(userPlugin, []byte("export default async () => ({})\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter, err := lookupHookAdapter("opencode")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 0; i < 2; i++ {
+		if _, _, err := adapter.install("project", false); err != nil {
+			t.Fatalf("install %d failed: %v", i+1, err)
+		}
+	}
+
+	entries, err := os.ReadDir(pluginsDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("expected exactly 2 plugin files after idempotent reinstall, got %d", len(entries))
+	}
+	if _, err := os.Stat(filepath.Join(pluginsDir, "cymbal-opencode.js")); err != nil {
+		t.Fatalf("expected managed plugin file to exist after reinstall: %v", err)
+	}
+
+	if _, _, err := adapter.uninstall("project", false); err != nil {
+		t.Fatalf("uninstall failed: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(pluginsDir, "cymbal-opencode.js")); !os.IsNotExist(err) {
+		t.Fatalf("expected managed plugin file to be removed; stat err=%v", err)
+	}
+	if data, err := os.ReadFile(userPlugin); err != nil {
+		t.Fatalf("expected unrelated user plugin to survive: %v", err)
+	} else if !strings.Contains(string(data), "export default") {
+		t.Fatalf("expected unrelated user plugin contents to survive, got %q", string(data))
+	}
+}
+
+func TestOpenCodeInstallUpgradesExistingManagedPluginInPlace(t *testing.T) {
+	dir := t.TempDir()
+	withTestWorkingDir(t, dir)
+
+	pluginsDir := filepath.Join(dir, ".opencode", "plugins")
+	if err := os.MkdirAll(pluginsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	managedPlugin := filepath.Join(pluginsDir, "cymbal-opencode.js")
+	oldContent := "// " + opencodeHookMarker + " managed by cymbal\n// cymbal-version: v0.0.1\nexport default async () => ({})\n"
+	if err := os.WriteFile(managedPlugin, []byte(oldContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter, err := lookupHookAdapter("opencode")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := adapter.install("project", false); err != nil {
+		t.Fatalf("install failed: %v", err)
+	}
+
+	data, err := os.ReadFile(managedPlugin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	if strings.Contains(got, "cymbal-version: v0.0.1") {
+		t.Fatalf("expected install to replace stale managed plugin content, got %q", got)
+	}
+	if !strings.Contains(got, "cymbal-version: "+currentVersion()) {
+		t.Fatalf("expected upgraded managed plugin to carry current version, got %q", got)
+	}
+	if !strings.Contains(got, `"tool.execute.before"`) {
+		t.Fatalf("expected upgraded managed plugin to carry current hook logic, got %q", got)
+	}
+}
+
+func TestOpenCodeInstallRefusesToOverwriteForeignPluginAtManagedPath(t *testing.T) {
+	dir := t.TempDir()
+	withTestWorkingDir(t, dir)
+
+	pluginsDir := filepath.Join(dir, ".opencode", "plugins")
+	if err := os.MkdirAll(pluginsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	managedPlugin := filepath.Join(pluginsDir, "cymbal-opencode.js")
+	foreign := "// user-owned file\nexport default async () => ({ custom: true })\n"
+	if err := os.WriteFile(managedPlugin, []byte(foreign), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter, err := lookupHookAdapter("opencode")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := adapter.install("project", false); err == nil {
+		t.Fatal("expected install to refuse overwriting foreign plugin file")
+	}
+
+	data, err := os.ReadFile(managedPlugin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != foreign {
+		t.Fatalf("expected foreign plugin file to remain untouched, got %q", string(data))
+	}
+}
+
+func TestOpenCodeInstallDryRunRefusesForeignPluginAtManagedPath(t *testing.T) {
+	dir := t.TempDir()
+	withTestWorkingDir(t, dir)
+
+	pluginsDir := filepath.Join(dir, ".opencode", "plugins")
+	if err := os.MkdirAll(pluginsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	managedPlugin := filepath.Join(pluginsDir, "cymbal-opencode.js")
+	foreign := "// user-owned file\nexport default async () => ({ custom: true })\n"
+	if err := os.WriteFile(managedPlugin, []byte(foreign), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter, err := lookupHookAdapter("opencode")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := adapter.install("project", true); err == nil {
+		t.Fatal("expected dry-run install to report overwrite refusal for foreign plugin file")
+	}
+
+	data, err := os.ReadFile(managedPlugin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != foreign {
+		t.Fatalf("expected foreign plugin file to remain untouched after dry-run, got %q", string(data))
+	}
+}
+
+func TestOpenCodeUninstallPreservesForeignPluginAtManagedPath(t *testing.T) {
+	dir := t.TempDir()
+	withTestWorkingDir(t, dir)
+
+	pluginsDir := filepath.Join(dir, ".opencode", "plugins")
+	if err := os.MkdirAll(pluginsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	managedPlugin := filepath.Join(pluginsDir, "cymbal-opencode.js")
+	foreign := "// user-owned file\nexport default async () => ({ custom: true })\n"
+	if err := os.WriteFile(managedPlugin, []byte(foreign), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter, err := lookupHookAdapter("opencode")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := adapter.uninstall("project", false); err != nil {
+		t.Fatalf("unexpected uninstall error for foreign plugin file: %v", err)
+	}
+
+	data, err := os.ReadFile(managedPlugin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != foreign {
+		t.Fatalf("expected foreign plugin file to survive uninstall, got %q", string(data))
+	}
+}
+
+func TestOpenCodeUninstallDryRunPreservesForeignPluginAtManagedPath(t *testing.T) {
+	dir := t.TempDir()
+	withTestWorkingDir(t, dir)
+
+	pluginsDir := filepath.Join(dir, ".opencode", "plugins")
+	if err := os.MkdirAll(pluginsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	managedPlugin := filepath.Join(pluginsDir, "cymbal-opencode.js")
+	foreign := "// user-owned file\nexport default async () => ({ custom: true })\n"
+	if err := os.WriteFile(managedPlugin, []byte(foreign), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter, err := lookupHookAdapter("opencode")
+	if err != nil {
+		t.Fatal(err)
+	}
+	target, summary, err := adapter.uninstall("project", true)
+	if err != nil {
+		t.Fatalf("unexpected dry-run uninstall error for foreign plugin file: %v", err)
+	}
+	if target != filepath.Join(".opencode", "plugins", "cymbal-opencode.js") {
+		t.Fatalf("unexpected dry-run uninstall target: %q", target)
+	}
+	if !strings.Contains(summary, "leave non-cymbal OpenCode plugin untouched") {
+		t.Fatalf("expected dry-run uninstall to reflect preservation of foreign plugin file, got %q", summary)
+	}
+
+	data, err := os.ReadFile(managedPlugin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != foreign {
+		t.Fatalf("expected foreign plugin file to survive dry-run uninstall, got %q", string(data))
+	}
+}
+
+func TestOpenCodeInstallRefusesWhenOtherScopeAlreadyHasManagedPlugin(t *testing.T) {
+	dir := t.TempDir()
+	withTestWorkingDir(t, dir)
+
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("HOMEDRIVE", "")
+	t.Setenv("HOMEPATH", "")
+
+	adapter, err := lookupHookAdapter("opencode")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := adapter.install("project", false); err != nil {
+		t.Fatalf("project-scope install failed: %v", err)
+	}
+	if _, _, err := adapter.install("user", false); err == nil {
+		t.Fatal("expected user-scope install to refuse when project-scope managed plugin already exists")
+	}
+}
+
+func withTestWorkingDir(t *testing.T, dir string) {
+	t.Helper()
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(wd); err != nil {
+			t.Fatal(err)
+		}
+	})
+}

--- a/docs/AGENT_HOOKS.md
+++ b/docs/AGENT_HOOKS.md
@@ -10,15 +10,19 @@ can wire into its native hook point:
 | `cymbal hook nudge` | Inspect a would-be shell command; if it looks like a code search, emit a short suggestion for the cymbal equivalent. Never blocks. |
 | `cymbal hook remind` | Print a short reminder block to inject at session start or on demand. Add `--update=if-stale` when the hook should refresh stale update status with a bounded live check. |
 
-Claude Code has a first-class installer:
+OpenCode and Claude Code have first-class installers:
 
 ```bash
+cymbal hook install opencode                 # ~/.config/opencode/plugins/cymbal-opencode.js
+cymbal hook install opencode --scope project
+cymbal hook uninstall opencode
+
 cymbal hook install claude-code              # ~/.claude/settings.json
 cymbal hook install claude-code --scope project
 cymbal hook uninstall claude-code
 ```
 
-Everyone else can wire the two subcommands in by hand. Snippets below.
+Other runtimes can wire the two subcommands in by hand. Snippets below.
 
 ---
 
@@ -194,16 +198,53 @@ cymbal hook remind > .zed/rules.md
 
 ## Opencode
 
-Opencode reads `AGENTS.md` as its primary rules file (project root or
-`~/.config/opencode/AGENTS.md` for global scope) and also composes extra
-files via `opencode.json` → `instructions`.
+The main supported OpenCode path is now a first-class installer:
 
-Opencode does not currently provide the same first-class session-start shell
-hook surface as Claude Code. Treat this integration as a best-effort bootstrap:
-it tells the agent to run the fresh-aware reminder command when a shell is
-available, rather than storing a stale reminder snapshot forever.
+```sh
+cymbal hook install opencode
+```
 
-**Project scope — append to `AGENTS.md`:**
+What it does:
+
+- **User scope** installs a cymbal-managed plugin at
+  `~/.config/opencode/plugins/cymbal-opencode.js`
+- **Project scope** installs a cymbal-managed plugin at
+  `.opencode/plugins/cymbal-opencode.js`
+- The plugin refreshes startup guidance by calling
+  `cymbal hook remind --format=text --update=if-stale`
+- The plugin soft-nudges bash `rg` / `grep` / `find` / `fd`-style commands
+  back toward cymbal-first navigation before the shell runs them on
+  non-Windows shells
+- Update guidance stays fresh automatically, but **cymbal still never
+  self-updates by default** — it only surfaces the explicit update command to
+  run
+
+Examples:
+
+```bash
+cymbal hook install opencode
+cymbal hook install opencode --scope project
+cymbal hook uninstall opencode
+```
+
+Upgrade / ownership behaviour:
+
+- Re-running `cymbal hook install opencode` upgrades an existing
+  **cymbal-managed** OpenCode plugin in place.
+- `cymbal hook uninstall opencode` removes only the cymbal-managed plugin file.
+- If a different user-owned file already exists at cymbal's target path,
+  cymbal refuses to overwrite or remove it.
+- Cymbal manages **one OpenCode scope at a time**. If a cymbal-managed plugin
+  already exists in the other scope, install refuses and asks you to uninstall
+  the other scope first.
+
+This is the preferred setup because it keeps OpenCode's cymbal guidance managed
+by cymbal itself instead of baking stale text into `AGENTS.md`.
+
+**Legacy / fallback bootstrap via `AGENTS.md`:**
+
+Use this only when plugins are unavailable or you explicitly want a manual
+instructions-only setup.
 
 ```bash
 cat >> AGENTS.md <<'EOF'
@@ -216,11 +257,7 @@ update guidance is needed.
 EOF
 ```
 
-Opencode also falls back to `CLAUDE.md` when no `AGENTS.md` is present, so
-repos already set up for Claude Code pick up the same reminder without
-duplication.
-
-**Composable alternative — dedicated file via `opencode.json`:**
+**Legacy / fallback bootstrap via `opencode.json` instructions:**
 
 This avoids collisions when `AGENTS.md` is shared with other agents
 (Codex, Cursor 0.42+, etc.) or already lives under version control:
@@ -246,10 +283,6 @@ Then add to `opencode.json` (or the global
 }
 ```
 
-Opencode supports globs and remote URLs in `instructions`, so teams can
-point at a shared source of truth instead of committing the reminder
-into every repo.
-
 **Windows global instructions path (PowerShell):**
 
 ```powershell
@@ -261,12 +294,6 @@ output as persistent navigation guidance. If shell access is unavailable,
 prefer cymbal for symbol navigation and ask the user to run the command when
 update guidance is needed.
 '@ | Set-Content -Encoding UTF8 "$HOME\.config\opencode\instructions\cymbal.md"
-```
-
-The resulting file lives at:
-
-```text
-C:\Users\<user>\.config\opencode\instructions\cymbal.md
 ```
 
 ---

--- a/docs/AGENT_HOOKS.md
+++ b/docs/AGENT_HOOKS.md
@@ -13,7 +13,7 @@ can wire into its native hook point:
 OpenCode and Claude Code have first-class installers:
 
 ```bash
-cymbal hook install opencode                 # ~/.config/opencode/plugins/cymbal-opencode.js
+cymbal hook install opencode                 # <user-config-dir>/opencode/plugins/cymbal-opencode.js
 cymbal hook install opencode --scope project
 cymbal hook uninstall opencode
 
@@ -207,7 +207,7 @@ cymbal hook install opencode
 What it does:
 
 - **User scope** installs a cymbal-managed plugin at
-  `~/.config/opencode/plugins/cymbal-opencode.js`
+  `<user-config-dir>/opencode/plugins/cymbal-opencode.js`
 - **Project scope** installs a cymbal-managed plugin at
   `.opencode/plugins/cymbal-opencode.js`
 - The plugin refreshes startup guidance by calling

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -60,6 +60,22 @@ The index auto-builds on first use, so a manual `cymbal index .` step is optiona
 
 ## Agent Integration
 
+If you use OpenCode, the main supported setup is a one-line installer:
+
+```sh
+cymbal hook install opencode
+```
+
+This installs a cymbal-managed plugin into OpenCode's plugin directory for the
+chosen scope. The plugin refreshes startup guidance with
+`cymbal hook remind --update=if-stale` and soft-nudges bash grep/find/fd-style
+commands back toward cymbal-first navigation on non-Windows shells. Update guidance stays fresh
+without editing `AGENTS.md`. Cymbal still does not self-update by default; it
+only surfaces the explicit update command to run.
+
+cymbal can also be used through plain agent instructions when a runtime does
+not support native plugins or hooks.
+
 cymbal is designed to be an AI agent's code comprehension layer. Add this to your `CLAUDE.md` (or equivalent agent instructions):
 
 ```markdown

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -265,3 +265,97 @@ cymbal refs handleAuth --importers
 # Transitive impact
 cymbal refs handleAuth --impact
 ```
+
+---
+
+## `cymbal hook`
+
+Agent-integration helpers for session reminders, shell nudges, and supported
+agent installers.
+
+```sh
+cymbal hook <subcommand> [flags]
+```
+
+### `cymbal hook remind`
+
+Print the short persistent guidance block agents should treat as system
+context.
+
+```sh
+cymbal hook remind [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--format <fmt>` | `text` (default), `json`, or `claude-code` |
+| `--update <mode>` | `cache` (default) or `if-stale` |
+
+- `--update=cache` uses cached update status only.
+- `--update=if-stale` performs a bounded live update check only when cache is stale or missing.
+- Reminder output can surface update guidance, but cymbal still never self-updates by default.
+
+### `cymbal hook nudge`
+
+Inspect a would-be shell command and, if it looks like code navigation through
+`rg`, `grep`, `find`, or `fd`, emit a cymbal suggestion.
+
+```sh
+cymbal hook nudge [--format <fmt>] [-- <command> [args...]]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--format <fmt>` | `claude-code` (default), `text`, or `json` |
+
+- Exit code is always `0`.
+- `text` writes the suggestion to stderr.
+- `json` emits a generic `suggest` / `why` payload for non-Claude integrations.
+
+### `cymbal hook install`
+
+Install cymbal-managed integration for a supported agent.
+
+```sh
+cymbal hook install <agent> [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--scope <scope>` | `user` (default) or `project` |
+| `--dry-run` | Print the target path and intended managed content without writing |
+
+Supported agents:
+
+- `opencode`
+- `claude-code`
+
+Examples:
+
+```sh
+cymbal hook install opencode
+cymbal hook install opencode --scope project
+cymbal hook install opencode --scope project --dry-run
+cymbal hook install claude-code
+```
+
+For `opencode`, re-running install upgrades the existing cymbal-managed plugin
+file in place. If a non-cymbal file already exists at cymbal's target path,
+install refuses to overwrite it.
+
+Only one cymbal-managed OpenCode scope is supported at a time. If a managed
+plugin already exists in the other scope, install refuses until that scope is
+uninstalled.
+
+### `cymbal hook uninstall`
+
+Remove cymbal-managed integration for a supported agent.
+
+```sh
+cymbal hook uninstall <agent> [flags]
+```
+
+The same `--scope` and `--dry-run` flags apply.
+
+For `opencode`, uninstall removes only the cymbal-managed plugin file and
+leaves unrelated user-owned files untouched.


### PR DESCRIPTION
﻿## Summary

- Add a first-class OpenCode installer with `cymbal hook install opencode`.
- Replace the docs-first OpenCode bootstrap story with a cymbal-managed local plugin that keeps reminder guidance fresh through `cymbal hook remind --update=if-stale`.
- Address issue #45 by making OpenCode the primary supported integration path while keeping AGENTS.md and `opencode.json` instruction flows as fallback guidance.
- Scope note: this gets Windows to the same first-class installer and fresh reminder flow as other platforms, but command-level shell nudges remain limited to non-Windows shells because OpenCode does not currently expose the same kind of structured advisory hook surface that Claude Code does.

Closes #45

## Testing

- Commands run:
  - `go test ./cmd`
  - `go test ./cmd -run "OpenCode|LookupHookAdapter|ClaudeCodeInstall|EmitRemind|EmitNudge"`
  - `go build ./...`
  - `go vet ./...`
  - `node --check cmd/hook_assets/opencode/cymbal-opencode.js`
- Extra validation:
  - Installed and uninstalled the managed OpenCode plugin in both project and user scope.
  - Verified dry-run behavior for managed files, foreign files, and cross-scope refusal.
  - Verified upgrade-in-place for an existing cymbal-managed plugin file.
  - Verified docs and command help alignment for the OpenCode-first path.
  - I did not use full `go test ./...` as the final gate because this Windows environment has unrelated non-OpenCode failures outside the changed surface. The cmd package and all changed-area validations are green.

## Checklist

- [x] I ran the required checks locally, or I explained why I could not in the Testing section.
- [x] I reviewed the diff for unrelated, generated, or vendored changes.
- [x] I updated docs, benchmarks, or release notes when behavior changed, or I explained why no updates were needed.
- [x] I filled out the Security Notes and Risks / Rollout sections below.

## Security Notes

- User input, file parsing, shell execution, or network behavior touched: yes. The OpenCode plugin invokes `cymbal hook remind` and `cymbal hook nudge` from the local plugin runtime. The installer now uses managed-file ownership checks, dry-run ownership checks, unique temp-file writes, and symlink checks before writing the OpenCode plugin file.
- New dependencies or vendored code added: no runtime dependencies. CI now uses `actions/setup-node@v4` to run a syntax check on the embedded OpenCode plugin asset.
- Secrets, credentials, or tokens touched: no.
- Follow-up needed: OpenCode shell-command nudges are still limited to non-Windows shells. A future follow-up can revisit a more OS-agnostic advisory path if OpenCode exposes one.

## Risks / Rollout

- Risk level: medium. This changes the main OpenCode integration story, adds a managed local plugin, and updates installer behavior. The main residual risk is behavioral drift in the OpenCode plugin runtime, especially around shell-command nudges.
- Rollback plan: uninstall the managed plugin with `cymbal hook uninstall opencode` and revert the branch or release if needed. Users can fall back to the existing AGENTS.md or `opencode.json` instructions-based setup.
