### PR TITLE
fix(cmd): silence Cobra Usage dump on RunE errors

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -15,6 +15,8 @@ var rootCmd = &cobra.Command{
 	Long: `Cymbal is a blazing-fast code indexer, parser, and symbol discovery CLI.
 It uses tree-sitter for multi-language AST parsing and SQLite for indexed storage,
 designed to be called by AI agents and developer tools.`,
+	// Don't dump Usage on RunE errors — keeps "no results found" exits clean.
+	SilenceUsage: true,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
 		return prepareUpdateNotice(cmd)
 	},


### PR DESCRIPTION
## Summary

Cobra prints the full Usage/Flags block to stderr whenever a command's `RunE` returns a non-nil error. For cymbal that fires on every "no results found" exit (e.g. `cymbal search foo` with no matches), drowning the real error message in ~20 lines of help text.

This is noise for both humans and the AI agents cymbal targets — agents often re-read the Usage block as a hint to retry with different flags, which it isn't. The actual signal (`Error: no results found for 'foo'`) gets lost.

The fix is one line: set `SilenceUsage: true` on the root command so it inherits to all subcommands. Errors themselves still print (`SilenceErrors` stays false), and `--help` plus unknown-flag paths continue to show Usage as Cobra normally does.

## Before

```
$ cymbal search xyzthisdoesnotexist123
xyzthisdoesnotexist123: no results found
Error: no results found for 'xyzthisdoesnotexist123'
Usage:
  cymbal search <query> [path ...] [flags]

Flags:
  -e, --exact                 exact name match only
      --exclude stringArray   exclude results whose path matches this glob (repeatable)
  -h, --help                  help for search
  ... (15 more lines) ...

Global Flags:
  -d, --db string   path to cymbal database (default: auto per-repo)
      --json        output as JSON
```

## After

```
$ cymbal search xyzthisdoesnotexist123
xyzthisdoesnotexist123: no results found
Error: no results found for 'xyzthisdoesnotexist123'
```

(exit code 1 preserved)

## Test plan

- [x] Built locally with `CGO_CFLAGS="-DSQLITE_ENABLE_FTS5" go build`.
- [x] Verified no-results case: Usage block gone, error + exit 1 preserved.
- [x] Verified `cymbal search --help` still prints Usage (it's a help flow, not a RunE error).
- [x] Verified `cymbal search --bogusflag` still prints `Error: unknown flag` (Cobra's flag-parse errors are unaffected by SilenceUsage).
- [x] Ran `go test ./cmd/...` — same 4 failures on this branch and `main` (pre-existing macOS `/var` → `/private/var` symlink issues, unrelated).