### PR TITLE
Fix release tests on macOS temp paths

### DIFF
--- a/cmd/diff.go
+++ b/cmd/diff.go
@@ -85,7 +85,9 @@ func runDiff(dbPath, name, base string, stat, jsonOut bool) error {
 	}
 
 	// Compute relative path from repo root.
-	relPath, err := filepath.Rel(repoRoot, sym.File)
+	repoRoot = canonicalExistingPath(repoRoot)
+	symFile := canonicalExistingPath(sym.File)
+	relPath, err := filepath.Rel(repoRoot, symFile)
 	if err != nil {
 		return fmt.Errorf("computing relative path: %w", err)
 	}
@@ -177,6 +179,18 @@ func gitRepoRoot(dir string) (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(string(out)), nil
+}
+
+func canonicalExistingPath(path string) string {
+	abs, err := filepath.Abs(path)
+	if err == nil {
+		path = abs
+	}
+	resolved, err := filepath.EvalSymlinks(path)
+	if err == nil {
+		return resolved
+	}
+	return filepath.Clean(path)
 }
 
 // filterDiffHunks filters unified diff output to only hunks whose new-file

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -1007,10 +1007,10 @@ func ensureSafeManagedTarget(path string) error {
 		if info.Mode()&os.ModeSymlink != 0 {
 			return fmt.Errorf("refusing to write inside symlinked OpenCode plugin directory %s", dir)
 		}
-		next := filepath.Dir(dir)
-		if next == dir {
-			break
-		}
+		// Stop at the first existing, non-symlink ancestor. This still catches
+		// symlinks inside the managed plugin path, while allowing platform-level
+		// aliases such as macOS /var -> /private/var.
+		return nil
 	}
 	return nil
 }

--- a/cmd/hook_test.go
+++ b/cmd/hook_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -643,6 +644,45 @@ func TestOpenCodeInstallUserScopeWritesManagedPlugin(t *testing.T) {
 	}
 }
 
+func TestOpenCodeInstallAllowsSymlinkedAncestorOutsideConfigRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is not consistently available on Windows")
+	}
+	home := t.TempDir()
+	base := t.TempDir()
+	realRoot := filepath.Join(base, "real")
+	if err := os.Mkdir(realRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linkRoot := filepath.Join(base, "link")
+	if err := os.Symlink(realRoot, linkRoot); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	configRoot := filepath.Join(linkRoot, "config")
+	if err := os.Mkdir(configRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("HOMEDRIVE", "")
+	t.Setenv("HOMEPATH", "")
+	t.Setenv("XDG_CONFIG_HOME", configRoot)
+	t.Setenv("APPDATA", configRoot)
+
+	adapter, err := lookupHookAdapter("opencode")
+	if err != nil {
+		t.Fatal(err)
+	}
+	target, _, err := adapter.install("user", false)
+	if err != nil {
+		t.Fatalf("install failed through symlinked ancestor outside config root: %v", err)
+	}
+	if _, err := os.Stat(target); err != nil {
+		t.Fatalf("expected managed plugin file at %s: %v", target, err)
+	}
+}
+
 func TestOpenCodeInstallDryRunDoesNotWrite(t *testing.T) {
 	dir := t.TempDir()
 	withTestWorkingDir(t, dir)
@@ -915,6 +955,9 @@ func TestOpenCodeInstallRefusesWhenOtherScopeAlreadyHasManagedPlugin(t *testing.
 
 func withTestWorkingDir(t *testing.T, dir string) {
 	t.Helper()
+	configRoot := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", configRoot)
+	t.Setenv("APPDATA", configRoot)
 	wd, err := os.Getwd()
 	if err != nil {
 		t.Fatal(err)

--- a/index/index.go
+++ b/index/index.go
@@ -89,6 +89,7 @@ func RepoDBPath(repoRoot string) (string, error) {
 	if err != nil {
 		return "", err
 	}
+	repoRoot = canonicalPath(repoRoot)
 	h := sha256.Sum256([]byte(repoRoot))
 	hash := hex.EncodeToString(h[:8]) // 16 hex chars
 	return filepath.Join(base, "repos", hash, "index.db"), nil
@@ -117,6 +118,18 @@ func FindGitRoot(dir string) (string, error) {
 		d = parent
 	}
 	return "", fmt.Errorf("no git repository found from %s", dir)
+}
+
+func canonicalPath(path string) string {
+	abs, err := filepath.Abs(path)
+	if err == nil {
+		path = abs
+	}
+	resolved, err := filepath.EvalSymlinks(path)
+	if err == nil {
+		return resolved
+	}
+	return filepath.Clean(path)
 }
 
 // parseResult holds the output of a parse worker.
@@ -194,6 +207,7 @@ func Index(root, dbPath string, opts Options) (*Stats, error) {
 	if workers <= 0 {
 		workers = runtime.NumCPU()
 	}
+	root = canonicalPath(root)
 
 	if dbPath == "" {
 		var err error
@@ -406,11 +420,7 @@ func autoDetectRoot() string {
 	if err != nil {
 		return ""
 	}
-	abs, err := filepath.Abs(root)
-	if err != nil {
-		return ""
-	}
-	return abs
+	return canonicalPath(root)
 }
 
 // startProgress launches a goroutine that prints indexing progress to stderr.
@@ -514,6 +524,7 @@ func FileOutline(dbPath, filePath string) ([]SymbolResult, error) {
 	if err != nil {
 		return nil, err
 	}
+	filePath = canonicalPath(filePath)
 	return store.FileSymbols(filePath)
 }
 

--- a/index/index_phase3_test.go
+++ b/index/index_phase3_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -97,19 +98,20 @@ func runPhase3Git(t *testing.T, repo string, args ...string) {
 
 func TestPhase3IndexFacadeQueries(t *testing.T) {
 	repo, dbPath := newPhase3Repo(t)
+	wantRepo := canonicalPath(repo)
 
 	stats, err := RepoStats(dbPath)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if stats.Path != repo || stats.SymbolCount == 0 || stats.Languages["go"] == 0 {
+	if stats.Path != wantRepo || stats.SymbolCount == 0 || stats.Languages["go"] == 0 {
 		t.Fatalf("unexpected repo stats: %+v", stats)
 	}
 	structure, err := Structure(dbPath, 10)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if structure.RepoRoot != repo || structure.Symbols == 0 {
+	if structure.RepoRoot != wantRepo || structure.Symbols == 0 {
 		t.Fatalf("Structure() = %+v", structure)
 	}
 
@@ -117,7 +119,7 @@ func TestPhase3IndexFacadeQueries(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(repos) != 1 || repos[0].Path != repo {
+	if len(repos) != 1 || repos[0].Path != wantRepo {
 		t.Fatalf("ListRepos() = %+v, want repo %s", repos, repo)
 	}
 
@@ -216,6 +218,57 @@ func TestPhase3IndexFacadeQueries(t *testing.T) {
 	}
 	if root := RepoRootFromDB(dbPath); root != repo {
 		t.Fatalf("RepoRootFromDB() = %q, want %q", root, repo)
+	}
+}
+
+func TestFeatureIndexCanonicalizesSymlinkedRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink creation is not consistently available on Windows")
+	}
+	t.Setenv("CYMBAL_CACHE_DIR", t.TempDir())
+
+	base := t.TempDir()
+	realRepo := filepath.Join(base, "real")
+	if err := os.Mkdir(realRepo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linkRepo := filepath.Join(base, "link")
+	if err := os.Symlink(realRepo, linkRepo); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+	writePhase3File(t, realRepo, "main.go", "package main\n\nfunc ThroughSymlink() {}\n")
+
+	dbPath := filepath.Join(t.TempDir(), "canonical.db")
+	if _, err := Index(linkRepo, dbPath, Options{Workers: 1, Force: true}); err != nil {
+		t.Fatal(err)
+	}
+
+	outlineFromReal, err := FileOutline(dbPath, filepath.Join(realRepo, "main.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !symbolsContain(outlineFromReal, "ThroughSymlink") {
+		t.Fatalf("outline via real path missing symbol: %+v", outlineFromReal)
+	}
+	outlineFromLink, err := FileOutline(dbPath, filepath.Join(linkRepo, "main.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !symbolsContain(outlineFromLink, "ThroughSymlink") {
+		t.Fatalf("outline via symlink path missing symbol: %+v", outlineFromLink)
+	}
+
+	store, err := OpenStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+	repoRoot, err := store.GetMeta("repo_root")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if repoRoot != canonicalPath(realRepo) {
+		t.Fatalf("repo_root = %q, want canonical %q", repoRoot, canonicalPath(realRepo))
 	}
 }
 


### PR DESCRIPTION
## Summary
- canonicalize repo/file paths at index, outline, and diff boundaries so macOS /var and /private/var spellings share the same DB and git-relative paths
- stop OpenCode symlink checks at the first existing non-symlink managed-path ancestor so normal platform aliases do not block installs
- isolate OpenCode project-scope tests from the developer's user config

## Verification
- make build-check
- make lint
- CGO_CFLAGS="-DSQLITE_ENABLE_FTS5" go test ./...
- make test-coverage
- focused release failure regressions for Codecov diff, phase2 outline/diff, OpenCode user install, symlinked index root