### PR TITLE
fix: upgrade Go to 1.26.3 to resolve 10 stdlib security vulnerabilities

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/1broseidon/cymbal
 
-go 1.25.9
+go 1.26.3
 
 require (
 	github.com/coder3101/tree-sitter-proto v0.0.0-20250826173151-a1fbf36c3029


### PR DESCRIPTION
## Summary

- Bumps the `go` directive in `go.mod` from `1.25.9` to `1.26.3`
- Resolves all 10 vulnerabilities reported by `govulncheck` — all were in the Go standard library
- Ran `go mod tidy` to regenerate `go.sum` for the new toolchain

## Vulnerabilities fixed

| ID | Package | Fixed in |
|----|---------|----------|
| GO-2026-4971 | `net` — Panic in Dial/LookupPort with NUL byte on Windows | go1.26.3 |
| GO-2026-4918 | `net/http` — Infinite loop in HTTP/2 transport with bad SETTINGS_MAX_FRAME_SIZE | go1.26.3 |
| GO-2026-4870 | `crypto/tls` — Unauthenticated TLS 1.3 KeyUpdate causes connection retention / DoS | go1.26.2 |
| GO-2026-4947 | `crypto/x509` — Unexpected work during chain building | go1.26.2 |
| GO-2026-4946 | `crypto/x509` — Inefficient policy validation | go1.26.2 |
| GO-2026-4866 | `crypto/x509` — Case-sensitive excludedSubtrees name constraints (auth bypass) | go1.26.2 |
| GO-2026-4602 | `os` — FileInfo can escape from a Root | go1.26.1 |
| GO-2026-4601 | `net/url` — Incorrect parsing of IPv6 host literals | go1.26.1 |
| GO-2026-4600 | `crypto/x509` — Panic in name constraint checking for malformed certs | go1.26.1 |
| GO-2026-4599 | `crypto/x509` — Incorrect enforcement of email constraints | go1.26.1 |

## Test plan

- [x] `make ci` passes cleanly (`build-check`, `lint`, `test`, `vulncheck`)
- [x] `govulncheck` reports: **No vulnerabilities found**
- [x] All existing tests pass (11 packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)