### PR TITLE
hook remind: clarify scope, acknowledge complementary tools

### DIFF
--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -797,7 +797,7 @@ func emitNudge(stdout, stderr io.Writer, format string, fields []string, s Sugge
 
 // reminderText is the short, tone-calibrated system block we ask agents
 // to treat as persistent context. Short by design.
-const reminderText = `This project is indexed by cymbal. Treat cymbal as the default code-navigation interface.
+const reminderText = `This project is indexed by cymbal. Use cymbal for structural code navigation when you know (or can guess) the symbol name.
 
 Default workflow:
   1. ` + "`cymbal search <name>`" + ` to locate a symbol or file by name.
@@ -808,7 +808,9 @@ Batch related lookups in one call when possible: ` + "`cymbal search Foo Bar`" +
 
 Prefer ` + "`cymbal search`" + ` over the Grep tool (or rg/grep) for symbol/function/class lookup. Prefer ` + "`cymbal show`" + ` over Read when reading source by symbol name. Prefer ` + "`cymbal investigate / impact / trace / impls`" + ` over manual cross-referencing.
 
-Use ` + "`cymbal search --text <pattern>`" + ` only for literal text or regex. Use Grep/Glob/Read (or rg/grep/find) for: literal text in non-code files (markdown, JSON, logs, config), files outside the indexed repo, and direct path reads when you already know the path.`
+Use ` + "`cymbal search --text <pattern>`" + ` only for literal text or regex. Use Grep/Glob/Read (or rg/grep/find) for: literal text in non-code files (markdown, JSON, logs, config), files outside the indexed repo, and direct path reads when you already know the path.
+
+Cymbal is for structural queries (known names, call graphs, references). For semantic/conceptual queries ("find code related to X") where you don't know the exact symbol name, prefer a semantic search tool if one is configured.`
 
 const (
 	remindUpdateCache   = "cache"


### PR DESCRIPTION
## Summary

- Change the reminder text to accurately scope cymbal as a **structural** code navigation tool rather than claiming to be "the default code-navigation interface" for everything
- Add a closing paragraph that directs agents toward semantic search tools for conceptual queries

## Problem

The current `cymbal hook remind` output starts with:

> This project is indexed by cymbal. Treat cymbal as the default code-navigation interface.

When injected as `additionalContext` on SessionStart, this sets a mental model where cymbal is the only code navigation tool worth reaching for. This misdirects AI agents away from complementary semantic search tools (ColGREP, ck, Semble, etc.) that handle a fundamentally different class of query — conceptual searches where the user doesn't know the exact symbol name.

For example, a query like "find code related to energy balance" would be poorly served by `cymbal search` (FTS5 text match on symbol names) but well served by a semantic search tool (vector similarity on code semantics).

## Changes

**Before:**
> This project is indexed by cymbal. Treat cymbal as the default code-navigation interface.

**After:**
> This project is indexed by cymbal. Use cymbal for structural code navigation when you know (or can guess) the symbol name.

Plus a new closing paragraph:
> Cymbal is for structural queries (known names, call graphs, references). For semantic/conceptual queries ("find code related to X") where you don't know the exact symbol name, prefer a semantic search tool if one is configured.

## Rationale

Cymbal excels at structural navigation — symbol lookup, call graphs, impact analysis, references. These require knowing (or guessing) a name. Semantic search tools excel at conceptual queries — finding related code by meaning. The two are complementary, not competing. The reminder text should reflect this rather than claiming universal ownership of "code navigation."

## Test plan

- [x] All 354 tests pass
- [x] `cymbal hook remind` outputs the updated text
- [x] No tests assert on the exact reminder text content