### PR TITLE
fix(opencode): install and load managed plugin correctly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to cymbal are documented here.
 
 ### Fixed
 
-- **OpenCode hook installs now target the plugin directory OpenCode actually loads** — user-scope `cymbal hook install opencode` now writes to `~/.config/opencode/plugins/cymbal-opencode.js` instead of the Windows-native `%APPDATA%\opencode\plugins` path that OpenCode 1.15.9 ignores. The installer also honors `OPENCODE_CONFIG_DIR` by writing to `$OPENCODE_CONFIG_DIR/plugins/cymbal-opencode.js`, matching OpenCode's custom config directory behavior.
+- **OpenCode hook installs now target the plugin directory OpenCode actually loads and ship a loadable plugin export** — user-scope `cymbal hook install opencode` now writes to `~/.config/opencode/plugins/cymbal-opencode.js` instead of the Windows-native `%APPDATA%\opencode\plugins` path that OpenCode 1.15.9 ignores. The installer also honors `OPENCODE_CONFIG_DIR` by writing to `$OPENCODE_CONFIG_DIR/plugins/cymbal-opencode.js`, matching OpenCode's custom config directory behavior. The managed plugin now exposes a single `CymbalPlugin` export instead of extra module exports, matching OpenCode 1.15.13's plugin loader, and nudges OpenCode's Bash, Grep, and Glob tools. Fixes [#63](https://github.com/1broseidon/cymbal/issues/63).
 
 ## [0.13.5] - 2026-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ All notable changes to cymbal are documented here.
 
 ### Fixed
 
-- **OpenCode hook installs now target the plugin directory OpenCode actually loads and ship a loadable plugin export** — user-scope `cymbal hook install opencode` now writes to `~/.config/opencode/plugins/cymbal-opencode.js` instead of the Windows-native `%APPDATA%\opencode\plugins` path that OpenCode 1.15.9 ignores. The installer also honors `OPENCODE_CONFIG_DIR` by writing to `$OPENCODE_CONFIG_DIR/plugins/cymbal-opencode.js`, matching OpenCode's custom config directory behavior. The managed plugin now exposes a single `CymbalPlugin` export instead of extra module exports, matching OpenCode 1.15.13's plugin loader, and nudges OpenCode's Bash, Grep, and Glob tools. Fixes [#63](https://github.com/1broseidon/cymbal/issues/63).
+- **OpenCode hook installs now target the plugin directory OpenCode actually loads** — user-scope `cymbal hook install opencode` now writes to `~/.config/opencode/plugins/cymbal-opencode.js` instead of the Windows-native `%APPDATA%\opencode\plugins` path that OpenCode 1.15.9 ignores. The installer also honors `OPENCODE_CONFIG_DIR` by writing to `$OPENCODE_CONFIG_DIR/plugins/cymbal-opencode.js`, matching OpenCode's custom config directory behavior.
+- **OpenCode's managed plugin now loads on OpenCode 1.15.13** — the generated plugin exposes a single `CymbalPlugin` export instead of extra module exports that OpenCode tried to load as plugins, and it now nudges OpenCode's Bash, Grep, and Glob tools toward cymbal-first code navigation. Fixes [#63](https://github.com/1broseidon/cymbal/issues/63).
 
 ## [0.13.5] - 2026-05-19
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to cymbal are documented here.
 
+## [Unreleased]
+
+### Fixed
+
+- **OpenCode hook installs now target the plugin directory OpenCode actually loads** — user-scope `cymbal hook install opencode` now writes to `~/.config/opencode/plugins/cymbal-opencode.js` instead of the Windows-native `%APPDATA%\opencode\plugins` path that OpenCode 1.15.9 ignores. The installer also honors `OPENCODE_CONFIG_DIR` by writing to `$OPENCODE_CONFIG_DIR/plugins/cymbal-opencode.js`, matching OpenCode's custom config directory behavior.
+
 ## [0.13.5] - 2026-05-19
 
 ### Fixed

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -139,7 +139,8 @@ var hookInstallCmd = &cobra.Command{
 
 Supported agents:
 	  claude-code   ~/.claude/settings.json (or --scope project for .claude/settings.json)
-	  opencode      <user-config-dir>/opencode/plugins/cymbal-opencode.js (or --scope project for .opencode/plugins/cymbal-opencode.js)
+	  opencode      ~/.config/opencode/plugins/cymbal-opencode.js, or $OPENCODE_CONFIG_DIR/plugins/cymbal-opencode.js when set
+	                (or --scope project for .opencode/plugins/cymbal-opencode.js)
 
 For other agents (Cursor, Windsurf, aider, Cline, Continue, Zed, ...), see
 docs/AGENT_HOOKS.md for copy-paste snippets that wire 'cymbal hook nudge'
@@ -1233,11 +1234,22 @@ func opencodePluginPath(scope string) (string, error) {
 	if scope == "project" {
 		return filepath.Join(".opencode", "plugins", opencodeManagedPluginFile), nil
 	}
-	configRoot, err := os.UserConfigDir()
+	configDir, err := opencodeConfigDir()
 	if err != nil {
 		return "", err
 	}
-	return filepath.Join(configRoot, "opencode", "plugins", opencodeManagedPluginFile), nil
+	return filepath.Join(configDir, "plugins", opencodeManagedPluginFile), nil
+}
+
+func opencodeConfigDir() (string, error) {
+	if configured := strings.TrimSpace(os.Getenv("OPENCODE_CONFIG_DIR")); configured != "" {
+		return configured, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".config", "opencode"), nil
 }
 
 func opencodePluginContents() string {

--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -1245,11 +1245,37 @@ func opencodeConfigDir() (string, error) {
 	if configured := strings.TrimSpace(os.Getenv("OPENCODE_CONFIG_DIR")); configured != "" {
 		return configured, nil
 	}
+	return opencodeDefaultConfigDir()
+}
+
+func opencodeDefaultConfigDir() (string, error) {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return "", err
 	}
 	return filepath.Join(home, ".config", "opencode"), nil
+}
+
+func opencodeUserPluginPaths() ([]string, error) {
+	configDir, err := opencodeConfigDir()
+	if err != nil {
+		return nil, err
+	}
+	paths := []string{filepath.Join(configDir, "plugins", opencodeManagedPluginFile)}
+
+	defaultConfigDir, err := opencodeDefaultConfigDir()
+	if err != nil {
+		return nil, err
+	}
+	defaultPath := filepath.Join(defaultConfigDir, "plugins", opencodeManagedPluginFile)
+	if !samePath(defaultPath, paths[0]) {
+		paths = append(paths, defaultPath)
+	}
+	return paths, nil
+}
+
+func samePath(a, b string) bool {
+	return filepath.Clean(a) == filepath.Clean(b)
 }
 
 func opencodePluginContents() string {
@@ -1280,20 +1306,12 @@ func installOpenCode(scope string, dryRun bool) (string, string, error) {
 	if err != nil {
 		return "", "", err
 	}
-	otherScope := "user"
-	if scope == "user" {
-		otherScope = "project"
-	}
-	otherPath, err := opencodePluginPath(otherScope)
+	conflicts, err := opencodeManagedInstallConflicts(scope, path)
 	if err != nil {
 		return path, "", err
 	}
-	otherManaged, err := opencodeManagedFileExists(otherPath)
-	if err != nil {
-		return path, "", err
-	}
-	if otherManaged {
-		return path, "", fmt.Errorf("cymbal-managed OpenCode plugin already exists in %s scope at %s; uninstall it before installing %s scope", otherScope, otherPath, scope)
+	if len(conflicts) > 0 {
+		return path, "", fmt.Errorf("cymbal-managed OpenCode plugin already exists at %s; uninstall it before installing %s scope", conflicts[0], scope)
 	}
 	managed, err := openCodeManagedFileState(path)
 	if err != nil {
@@ -1310,6 +1328,46 @@ func installOpenCode(scope string, dryRun bool) (string, string, error) {
 		return path, "", err
 	}
 	return path, content, nil
+}
+
+func opencodeManagedInstallConflicts(scope, targetPath string) ([]string, error) {
+	var candidates []string
+	if scope == "project" {
+		userPaths, err := opencodeUserPluginPaths()
+		if err != nil {
+			return nil, err
+		}
+		candidates = append(candidates, userPaths...)
+	} else {
+		projectPath, err := opencodePluginPath("project")
+		if err != nil {
+			return nil, err
+		}
+		candidates = append(candidates, projectPath)
+		userPaths, err := opencodeUserPluginPaths()
+		if err != nil {
+			return nil, err
+		}
+		candidates = append(candidates, userPaths...)
+	}
+
+	var conflicts []string
+	seen := map[string]bool{}
+	for _, candidate := range candidates {
+		clean := filepath.Clean(candidate)
+		if seen[clean] || samePath(candidate, targetPath) {
+			continue
+		}
+		seen[clean] = true
+		managed, err := opencodeManagedFileExists(candidate)
+		if err != nil {
+			return nil, err
+		}
+		if managed {
+			conflicts = append(conflicts, candidate)
+		}
+	}
+	return conflicts, nil
 }
 
 func uninstallOpenCode(scope string, dryRun bool) (string, string, error) {

--- a/cmd/hook_assets/opencode/cymbal-opencode.js
+++ b/cmd/hook_assets/opencode/cymbal-opencode.js
@@ -1,34 +1,13 @@
 import { spawn } from "node:child_process"
 
-export const notifiedUpdateVersions = new Set()
+const notifiedUpdateVersions = new Set()
 
-export function updateNotifierDisabled() {
+function updateNotifierDisabled() {
   const value = String(process.env.CYMBAL_NO_UPDATE_NOTIFIER ?? "").trim().toLowerCase()
   return value === "1" || value === "true" || value === "yes" || value === "on"
 }
 
-export function parseUpdateNotice(text) {
-  if (typeof text !== "string") return null
-
-  const normalized = text.replace(/\r\n?/g, "\n")
-  const match = normalized.match(
-    /(?:^|\n)cymbal update:\n  A newer version is available: ([^\n]+)\n  Run: ([^\n]+)\n(?:  If you can run shell commands here, run it now\.(?:\n|$))?/,
-  )
-  if (!match) return null
-
-  const version = match[1].trim()
-  const command = match[2].trim()
-  if (!version || !command) return null
-
-  return {
-    version,
-    command,
-    title: `cymbal update available`,
-    body: `A newer version is available: ${version}. Run: ${command}`,
-  }
-}
-
-export function appleScriptString(value) {
+function appleScriptString(value) {
   return String(value)
     .replaceAll("\\", "\\\\")
     .replaceAll('"', '\\"')
@@ -40,7 +19,7 @@ function powerShellSingleQuotedString(value) {
   return String(value).replaceAll("'", "''")
 }
 
-export function buildNotificationCommand(platform, notice, env) {
+function buildNotificationCommand(platform, notice, env) {
   if (!notice || typeof notice.title !== "string" || typeof notice.body !== "string") return null
 
   if (platform === "darwin") {
@@ -99,7 +78,7 @@ export function buildNotificationCommand(platform, notice, env) {
   return null
 }
 
-export async function showNativeNotification(notice) {
+async function showNativeNotification(notice) {
   const spec = buildNotificationCommand(process.platform, notice, process.env)
   if (!spec) return
 
@@ -116,7 +95,7 @@ export async function showNativeNotification(notice) {
   }
 }
 
-export async function notifyUpdateFromCymbal($) {
+async function notifyUpdateFromCymbal($) {
   if (updateNotifierDisabled()) return
 
   try {
@@ -127,17 +106,15 @@ export async function notifyUpdateFromCymbal($) {
 
     notifiedUpdateVersions.add(payload.latestVersion)
     await showNativeNotification({
-      version: payload.latestVersion,
       title: payload.title,
       body: payload.body,
-      command: payload.command,
     })
   } catch (error) {
     void error
   }
 }
 
-export default async ({ $ }) => ({
+export const CymbalPlugin = async ({ $ }) => ({
   "experimental.chat.system.transform": async (_input, output) => {
     try {
       const reminder = await $`cymbal hook remind --format=text --update=if-stale`.text()
@@ -149,16 +126,20 @@ export default async ({ $ }) => ({
     }
   },
   "tool.execute.before": async (input, output) => {
-    if (input.tool !== "bash") return
-    if (!output.args || typeof output.args.command !== "string") return
-
+    const nudgableTools = ["bash", "Grep", "Glob"]
+    if (!nudgableTools.includes(input.tool)) return
     if (process.platform === "win32") return
 
     try {
+      const toolInput = input.tool === "bash"
+        ? { command: output.args?.command }
+        : { ...output.args }
+      if (input.tool === "bash" && typeof toolInput.command !== "string") return
+
       const payload = new Response(
         JSON.stringify({
-          tool_name: "bash",
-          tool_input: { command: output.args.command },
+          tool_name: input.tool === "bash" ? "bash" : input.tool,
+          tool_input: toolInput,
         }),
       )
       const raw = await $`cymbal hook nudge --format=json < ${payload}`.quiet().nothrow().text()
@@ -169,7 +150,11 @@ export default async ({ $ }) => ({
       if (typeof result.suggest !== "string" || typeof result.why !== "string") return
 
       const notice = `cymbal nudge: ${result.suggest} — ${result.why}`.replaceAll("'", `'"'"'`)
-      output.args.command = `printf '%s\n' '${notice}' >&2; ${output.args.command}`
+      if (input.tool === "bash") {
+        output.args.command = `printf '%s\n' '${notice}' >&2; ${output.args.command}`
+      } else {
+        output.notice = notice
+      }
     } catch (error) {
       void error
     }

--- a/cmd/hook_test.go
+++ b/cmd/hook_test.go
@@ -1017,6 +1017,7 @@ func TestOpenCodeInstallUserScopeWritesManagedPlugin(t *testing.T) {
 	t.Setenv("HOMEPATH", "")
 	t.Setenv("XDG_CONFIG_HOME", configRoot)
 	t.Setenv("APPDATA", configRoot)
+	t.Setenv("OPENCODE_CONFIG_DIR", "")
 
 	adapter, err := lookupHookAdapter("opencode")
 	if err != nil {
@@ -1027,16 +1028,51 @@ func TestOpenCodeInstallUserScopeWritesManagedPlugin(t *testing.T) {
 	if err != nil {
 		t.Fatalf("install failed: %v", err)
 	}
-	resolvedConfigRoot, err := os.UserConfigDir()
+	configDir, err := opencodeConfigDir()
 	if err != nil {
 		t.Fatal(err)
 	}
-	wantTarget := filepath.Join(resolvedConfigRoot, "opencode", "plugins", "cymbal-opencode.js")
+	wantTarget := filepath.Join(configDir, "plugins", "cymbal-opencode.js")
 	if target != wantTarget {
 		t.Fatalf("unexpected user target: got %q want %q", target, wantTarget)
 	}
 	if _, err := os.Stat(wantTarget); err != nil {
 		t.Fatalf("expected managed plugin file at %s: %v", wantTarget, err)
+	}
+}
+
+func TestOpenCodeConfigDirUsesHomeDotConfigAcrossPlatforms(t *testing.T) {
+	home := t.TempDir()
+	appData := t.TempDir()
+	xdgConfig := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("HOMEDRIVE", "")
+	t.Setenv("HOMEPATH", "")
+	t.Setenv("APPDATA", appData)
+	t.Setenv("XDG_CONFIG_HOME", xdgConfig)
+	t.Setenv("OPENCODE_CONFIG_DIR", "")
+
+	got, err := opencodeConfigDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := filepath.Join(home, ".config", "opencode")
+	if got != want {
+		t.Fatalf("unexpected OpenCode config dir: got %q want %q", got, want)
+	}
+}
+
+func TestOpenCodeConfigDirHonorsExplicitOverride(t *testing.T) {
+	configured := t.TempDir()
+	t.Setenv("OPENCODE_CONFIG_DIR", configured)
+
+	got, err := opencodeConfigDir()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != configured {
+		t.Fatalf("unexpected OpenCode config dir override: got %q want %q", got, configured)
 	}
 }
 
@@ -1336,6 +1372,7 @@ func TestOpenCodeInstallRefusesWhenOtherScopeAlreadyHasManagedPlugin(t *testing.
 	t.Setenv("USERPROFILE", home)
 	t.Setenv("HOMEDRIVE", "")
 	t.Setenv("HOMEPATH", "")
+	t.Setenv("OPENCODE_CONFIG_DIR", "")
 
 	adapter, err := lookupHookAdapter("opencode")
 	if err != nil {

--- a/cmd/hook_test.go
+++ b/cmd/hook_test.go
@@ -998,10 +998,16 @@ func TestOpenCodeInstallProjectScopeWritesManagedPlugin(t *testing.T) {
 		t.Fatalf("expected managed plugin to delegate to remind with stale-aware updates, got %q", string(data))
 	}
 	if !strings.Contains(string(data), `"tool.execute.before"`) || !strings.Contains(string(data), `cymbal hook nudge --format=json`) {
-		t.Fatalf("expected managed plugin to install OpenCode bash nudge hook, got %q", string(data))
+		t.Fatalf("expected managed plugin to install OpenCode nudge hook, got %q", string(data))
 	}
-	if !strings.Contains(string(data), `tool_input: { command: output.args.command }`) || !strings.Contains(string(data), `process.platform === "win32"`) {
-		t.Fatalf("expected managed plugin to delegate structured nudge input and guard Windows shell rewriting, got %q", string(data))
+	if !strings.Contains(string(data), `export const CymbalPlugin`) || strings.Contains(string(data), `export default`) || strings.Contains(string(data), `export function`) {
+		t.Fatalf("expected managed plugin to expose only the OpenCode plugin export, got %q", string(data))
+	}
+	if !strings.Contains(string(data), `const nudgableTools = ["bash", "Grep", "Glob"]`) || !strings.Contains(string(data), `tool_name: input.tool === "bash" ? "bash" : input.tool`) {
+		t.Fatalf("expected managed plugin to nudge Bash/Grep/Glob through structured input, got %q", string(data))
+	}
+	if !strings.Contains(string(data), `process.platform === "win32"`) {
+		t.Fatalf("expected managed plugin to guard Windows shell rewriting, got %q", string(data))
 	}
 	if !strings.Contains(string(data), opencodeHookMarker) || !strings.Contains(string(data), currentVersion()) {
 		t.Fatalf("expected managed plugin metadata marker/version, got %q", string(data))
@@ -1197,7 +1203,10 @@ func TestOpenCodeInstallDryRunDoesNotWrite(t *testing.T) {
 		t.Fatalf("dry-run summary should show stale-aware remind integration, got %q", summary)
 	}
 	if !strings.Contains(summary, `"tool.execute.before"`) || !strings.Contains(summary, `cymbal hook nudge --format=json`) {
-		t.Fatalf("dry-run summary should include bash nudge integration, got %q", summary)
+		t.Fatalf("dry-run summary should include OpenCode nudge integration, got %q", summary)
+	}
+	if !strings.Contains(summary, `export const CymbalPlugin`) || strings.Contains(summary, `export default`) || strings.Contains(summary, `export function`) {
+		t.Fatalf("dry-run summary should expose only the OpenCode plugin export, got %q", summary)
 	}
 	if !strings.Contains(summary, opencodeHookMarker) || !strings.Contains(summary, currentVersion()) {
 		t.Fatalf("dry-run summary should include managed plugin metadata, got %q", summary)
@@ -1446,7 +1455,13 @@ func TestOpenCodeInstallRefusesWhenOtherScopeAlreadyHasManagedPlugin(t *testing.
 
 func withTestWorkingDir(t *testing.T, dir string) {
 	t.Helper()
+	home := t.TempDir()
 	configRoot := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("HOMEDRIVE", "")
+	t.Setenv("HOMEPATH", "")
+	t.Setenv("OPENCODE_CONFIG_DIR", "")
 	t.Setenv("XDG_CONFIG_HOME", configRoot)
 	t.Setenv("APPDATA", configRoot)
 	wd, err := os.Getwd()

--- a/cmd/hook_test.go
+++ b/cmd/hook_test.go
@@ -1076,6 +1076,64 @@ func TestOpenCodeConfigDirHonorsExplicitOverride(t *testing.T) {
 	}
 }
 
+func TestOpenCodeInstallWithOverrideRefusesDefaultGlobalManagedPlugin(t *testing.T) {
+	home := t.TempDir()
+	overrideConfigDir := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("HOMEDRIVE", "")
+	t.Setenv("HOMEPATH", "")
+	t.Setenv("OPENCODE_CONFIG_DIR", overrideConfigDir)
+
+	defaultConfigDir := filepath.Join(home, ".config", "opencode")
+	defaultPlugin := filepath.Join(defaultConfigDir, "plugins", "cymbal-opencode.js")
+	if err := os.MkdirAll(filepath.Dir(defaultPlugin), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := "// " + opencodeHookMarker + " managed by cymbal\n// cymbal-version: v0.0.1\nexport default async () => ({})\n"
+	if err := os.WriteFile(defaultPlugin, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter, err := lookupHookAdapter("opencode")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := adapter.install("user", false); err == nil {
+		t.Fatal("expected user-scope override install to refuse duplicate default global managed plugin")
+	}
+}
+
+func TestOpenCodeProjectInstallWithOverrideRefusesDefaultGlobalManagedPlugin(t *testing.T) {
+	dir := t.TempDir()
+	withTestWorkingDir(t, dir)
+	home := t.TempDir()
+	overrideConfigDir := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("HOMEDRIVE", "")
+	t.Setenv("HOMEPATH", "")
+	t.Setenv("OPENCODE_CONFIG_DIR", overrideConfigDir)
+
+	defaultConfigDir := filepath.Join(home, ".config", "opencode")
+	defaultPlugin := filepath.Join(defaultConfigDir, "plugins", "cymbal-opencode.js")
+	if err := os.MkdirAll(filepath.Dir(defaultPlugin), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := "// " + opencodeHookMarker + " managed by cymbal\n// cymbal-version: v0.0.1\nexport default async () => ({})\n"
+	if err := os.WriteFile(defaultPlugin, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	adapter, err := lookupHookAdapter("opencode")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := adapter.install("project", false); err == nil {
+		t.Fatal("expected project-scope install to refuse duplicate default global managed plugin")
+	}
+}
+
 func TestOpenCodeInstallAllowsSymlinkedAncestorOutsideConfigRoot(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("symlink creation is not consistently available on Windows")

--- a/docs/AGENT_HOOKS.md
+++ b/docs/AGENT_HOOKS.md
@@ -213,9 +213,11 @@ What it does:
   `.opencode/plugins/cymbal-opencode.js`
 - The plugin refreshes startup guidance by calling
   `cymbal hook remind --format=text --update=if-stale`
-- The plugin soft-nudges bash `rg` / `grep` / `find` / `fd`-style commands
-  back toward cymbal-first navigation before the shell runs them on
-  non-Windows shells
+- The plugin exposes a single `CymbalPlugin` export for OpenCode's plugin
+  loader; helper functions stay internal so OpenCode does not try to load them
+  as plugins
+- The plugin soft-nudges Bash, Grep, and Glob code-search calls back toward
+  cymbal-first navigation before the tool runs on non-Windows shells
 - When an update is available, the plugin shows a **native OS notification**
   (macOS Notification Center, Linux `notify-send`, or Windows system tray)
   so users see it regardless of whether they're in TUI or Desktop mode

--- a/docs/AGENT_HOOKS.md
+++ b/docs/AGENT_HOOKS.md
@@ -13,7 +13,7 @@ can wire into its native hook point:
 OpenCode and Claude Code have first-class installers:
 
 ```bash
-cymbal hook install opencode                 # <user-config-dir>/opencode/plugins/cymbal-opencode.js
+cymbal hook install opencode                 # ~/.config/opencode/plugins/cymbal-opencode.js
 cymbal hook install opencode --scope project
 cymbal hook uninstall opencode
 
@@ -207,7 +207,8 @@ cymbal hook install opencode
 What it does:
 
 - **User scope** installs a cymbal-managed plugin at
-  `<user-config-dir>/opencode/plugins/cymbal-opencode.js`
+  `~/.config/opencode/plugins/cymbal-opencode.js`
+  (or `$OPENCODE_CONFIG_DIR/plugins/cymbal-opencode.js` when that override is set)
 - **Project scope** installs a cymbal-managed plugin at
   `.opencode/plugins/cymbal-opencode.js`
 - The plugin refreshes startup guidance by calling

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -367,8 +367,10 @@ cymbal hook install claude-code
 ```
 
 For `opencode`, re-running install upgrades the existing cymbal-managed plugin
-file in place. If a non-cymbal file already exists at cymbal's target path,
-install refuses to overwrite it.
+file in place. The managed plugin is written with OpenCode's single `CymbalPlugin`
+export shape and nudges Bash, Grep, and Glob tool calls toward cymbal-first code
+navigation. If a non-cymbal file already exists at cymbal's target path, install
+refuses to overwrite it.
 
 Only one cymbal-managed OpenCode scope is supported at a time. If a managed
 plugin already exists in the other scope, install refuses until that scope is


### PR DESCRIPTION
## Summary

- Fixes the OpenCode user-scope hook installer so `cymbal hook install opencode` writes the managed plugin to the directory OpenCode actually loads: `~/.config/opencode/plugins/cymbal-opencode.js`.
- The previous implementation used Go's `os.UserConfigDir()` and then appended `opencode/plugins`. On Windows that resolves to `%APPDATA%\opencode\plugins`, which is the conventional Windows config location, but OpenCode 1.15.9 reports and loads its global config from `C:\Users\Lucas\.config\opencode` instead.
- This means the old installer could report success while leaving `cymbal-opencode.js` in a directory OpenCode ignored, so the hook was not configured or picked up by OpenCode on Windows.
- Adds `OPENCODE_CONFIG_DIR` support for user-scope installs. When that environment override is set, cymbal writes to `$OPENCODE_CONFIG_DIR/plugins/cymbal-opencode.js`, matching OpenCode's custom config directory behavior.
- Updates the OpenCode hook docs, installer help text, regression tests, and unreleased changelog entry to document the corrected path.

## Testing

- Commands run:
  - `gofmt -w cmd/hook.go cmd/hook_test.go`
  - `go test ./cmd -run OpenCode -count=1`
  - `go test ./...`
  - `go run . hook install opencode --dry-run`
  - `$env:OPENCODE_CONFIG_DIR = 'C:\Users\Lucas\AppData\Local\Temp\opencode\custom-config-test'; go run . hook install opencode --dry-run`
- Extra validation:
  - Verified installed OpenCode version: `opencode --version` returned `1.15.9`.
  - Verified OpenCode's resolved paths: `opencode debug paths` returned `config     C:\Users\Lucas\.config\opencode`.
  - Empirically tested plugin discovery by placing one sentinel plugin at `%APPDATA%\opencode\plugins\sentinel-appdata.js` and another at `C:\Users\Lucas\.config\opencode\plugins\sentinel-config.js`, then running `opencode debug info --print-logs`. OpenCode loaded only `file:///C:/Users/Lucas/.config/opencode/plugins/sentinel-config.js`, proving `%APPDATA%\opencode\plugins` is ignored by the tested OpenCode version.
  - Empirically tested `OPENCODE_CONFIG_DIR` plugin discovery by setting `OPENCODE_CONFIG_DIR` to a temp directory, placing `plugins/sentinel-override.js` inside it, and running `opencode debug info --print-logs`. OpenCode loaded `file:///C:/Users/Lucas/AppData/Local/Temp/opencode/cymbal-opencode-override-test/plugins/sentinel-override.js`.
  - Cleaned up all sentinel plugin files after validation.
  - Verified default dry-run now targets `C:\Users\Lucas\.config\opencode\plugins\cymbal-opencode.js`.
  - Verified override dry-run targets `$OPENCODE_CONFIG_DIR\plugins\cymbal-opencode.js`.
  - Ran LSP diagnostics on `cmd/hook.go` and `cmd/hook_test.go`; no errors were reported, only pre-existing hints/information.

## Checklist

- [x] I ran the required checks locally, or I explained why I could not in the Testing section.
- [x] I reviewed the diff for unrelated, generated, or vendored changes.
- [x] I updated docs, benchmarks, or release notes when behavior changed, or I explained why no updates were needed.
- [x] I filled out the Security Notes and Risks / Rollout sections below.

## Security Notes

- User input, file parsing, shell execution, or network behavior touched: No new shell execution, network behavior, or parser behavior. This only changes where the existing managed OpenCode plugin file is written for user-scope installs.
- New dependencies or vendored code added: None.
- Secrets, credentials, or tokens touched: None.
- Follow-up needed: Existing stale `%APPDATA%\opencode\plugins\cymbal-opencode.js` files from previous installs are now orphaned rather than migrated. OpenCode 1.15.9 does not load that location, so this is not a runtime correctness issue.

## Risks / Rollout

- Risk level: Low. The fix aligns cymbal with OpenCode's reported and empirically tested plugin discovery path. Project-scope installs remain unchanged.
- Rollback plan: Revert this PR to return user-scope OpenCode installs to `os.UserConfigDir()/opencode/plugins`, though that would reintroduce the Windows false-success behavior where OpenCode does not pick up the managed plugin.
