### PR TITLE
Post-merge audit fixes for the v0.14 triage features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to cymbal are documented here.
 
 ## [Unreleased]
 
+### Added
+
+- **`impact --no-tests` now works in `--graph` mode** — previously the graph path silently ignored `--no-tests` and rendered test callers anyway. Test-classified nodes are now contracted out of the graph with hide-but-traverse semantics: a production caller reachable only through a test helper stays connected to the seed via a synthesized dashed edge marked `"indirect": true`, instead of being orphaned or silently kept.
+- **Graphs report edge-fetch truncation** — `--graph` output built from more rows than the internal per-direction fetch cap (1000) now sets `edges_truncated: true` in JSON instead of silently rendering an incomplete graph. The trace core's truncation detection now also covers the graph's unresolved-exempt mode.
+- **New test-filename conventions recognised** — `.test.cjs`/`.spec.cjs`, `.test.mts`/`.spec.mts`, `.test.cts`/`.spec.cts` (module-flavoured JS/TS), PHPUnit `*Test.php`, Kotest `*Spec.kt`, and Django `tests.py`.
+
+### Changed
+
+- **BREAKING: `investigate --json` now returns one stable object shape for any symbol count** — previously a single symbol emitted a bare object and a batch emitted a bare array, so piped batches (`--stdin`) flipped shape based on how many names survived dedup. Both now emit `{symbols, resolve_scope, results: [...]}` (matching `trace`/`impact`), and every per-symbol entry carries its own `symbol` key (previously only error entries did).
+- **`trace` reports the effective (clamped) depth** — `trace --depth 10` used to echo `depth: 10` in frontmatter/JSON while actually traversing the maximum of 5; the reported depth now matches the traversal (`index.ClampTraceDepth`).
+
+### Fixed
+
+- **`changed`: in-hunk lines starting with `-- `/`++ ` are no longer misparsed as file headers** — a deleted line whose content begins with `-- ` renders in a unified diff as `--- …` (every deleted Lua comment; any block-comment content), which the parser previously treated as a `---` file header: it clobbered the file's paths and silently dropped the rest of the hunk's changed symbols. Hunk-body lines are now matched before header prefixes, which git only emits before a file's first hunk.
+- **`changed`: filenames containing spaces are now analyzed** — git appends a tab separator after unquoted header paths containing a space (`--- a/my file.go\t`); the parser kept the tab, so both blob reads failed and the file was miscounted as "no parseable symbols". Exactly one trailing tab is now stripped (safe: a filename with a real tab is always C-quoted).
+- **`changed`: user git config can no longer silently empty the results** — `diff.mnemonicPrefix=true` (headers become `i/`/`w/`), `diff.noprefix`, `diff.srcPrefix`/`dstPrefix`, `color.diff=always` (ANSI codes even when piped), and textconv drivers each broke the diff contract the parser assumes, producing "No changed symbols found" with no error. The git invocation now pins all of them (`-c` overrides plus `--no-color --no-textconv`).
+- **`changed`: real `git diff` failures now surface as errors** — a failure without stderr (or a non-exit error) was previously swallowed, and the run proceeded on empty output as a false "no changed symbols".
+- **`changed`: pure renames and mode-only changes are no longer miscounted** as "changed file(s) had no parseable symbols"; merge-conflict (unmerged) files, previously invisible, are now counted and warned about (`conflicted_files` in JSON).
+- **`changed --base <ref>`**: the ref is now separated from paths with `--`, so a file named like the ref (e.g. `main`) no longer makes git fail with "ambiguous argument"; `--json` emits `"results": []` instead of `null` when no symbols changed.
+- **Path classification now works on Windows** — the index stores rel paths with native separators, so every anchored pattern (`/tests/`, `src/test/java`, …) silently failed to match on Windows: `--no-tests` hid nothing, the production/test splits reported test code as production, and `search` ranking's test-file penalty never applied. `ClassifyPath` now normalizes `\` to `/` (and the bare-convention guard no longer inverts on `src\Test.java`).
+- **Impact/trace BFS no longer re-queries duplicate frontier entries** — a caller reached via several files (or a callee reached from several callers) was enqueued once per encounter and re-queried at the next depth; results were already deduplicated, so this was pure wasted SQL on hot symbols.
+
 ## [0.14.0] - 2026-06-20
 
 ### Added

--- a/cmd/changed.go
+++ b/cmd/changed.go
@@ -82,9 +82,13 @@ when truncated. Operates only on the current worktree.`,
 		}
 		out, err := exec.Command("git", append([]string{"-C", repoRoot}, diffArgs...)...).Output()
 		if err != nil {
+			// git diff (without --exit-code) only fails on real errors, so any
+			// failure must surface rather than proceed on empty output as a
+			// false "no changed symbols".
 			if exitErr, ok := err.(*exec.ExitError); ok && len(exitErr.Stderr) > 0 {
 				return fmt.Errorf("git diff: %s", strings.TrimSpace(string(exitErr.Stderr)))
 			}
+			return fmt.Errorf("git diff: %w", err)
 		}
 
 		// Old-side blob revision per mode: index ("" -> :path) for the default
@@ -114,9 +118,16 @@ when truncated. Operates only on the current worktree.`,
 		}
 
 		skipped := 0
+		conflicted := countConflictBlocks(string(out))
 		for _, f := range parseChangedFiles(string(out)) {
 			if f.Binary {
 				skipped++
+				continue
+			}
+			if f.OldPath == "" && f.NewPath == "" && len(f.OldLines) == 0 && len(f.NewLines) == 0 {
+				// Pure rename, copy, or mode-only change: a diff block with no
+				// ---/+++ headers and no hunks. No content changed, so it is
+				// neither analyzable nor a "no parseable symbols" skip.
 				continue
 			}
 			fileParsed := false
@@ -194,7 +205,7 @@ when truncated. Operates only on the current worktree.`,
 			Impact          *impactSummary        `json:"impact,omitempty"`
 			ImpactStatus    string                `json:"impact_status,omitempty"` // "cap" | "error"
 		}
-		var results []changedResult
+		results := make([]changedResult, 0, len(analyzed))
 		impactTruncated := false
 		aggRows := 0
 		for _, name := range analyzed {
@@ -266,11 +277,14 @@ when truncated. Operates only on the current worktree.`,
 			if skipped > 0 {
 				payload["skipped_files"] = skipped
 			}
+			if conflicted > 0 {
+				payload["conflicted_files"] = conflicted
+			}
 			return writeJSON(payload)
 		}
 
 		renderWarnings := func(b *strings.Builder) {
-			if len(deletedList) == 0 && skipped == 0 {
+			if len(deletedList) == 0 && skipped == 0 && conflicted == 0 {
 				return
 			}
 			b.WriteString("\nwarnings:\n")
@@ -279,6 +293,9 @@ when truncated. Operates only on the current worktree.`,
 			}
 			if skipped > 0 {
 				fmt.Fprintf(b, "  %d changed file(s) had no parseable symbols (binary, unsupported, or non-code)\n", skipped)
+			}
+			if conflicted > 0 {
+				fmt.Fprintf(b, "  %d conflicted file(s) (unmerged) not analyzed\n", conflicted)
 			}
 		}
 
@@ -359,14 +376,26 @@ func init() {
 }
 
 // changedDiffArgs builds the git-diff argument list for the requested mode and a
-// human label for the comparison base. core.quotePath=false reduces path
-// escaping; remaining C-quoted paths are decoded when parsed.
+// human label for the comparison base. The parser assumes plain uncolored
+// unified-diff output with a/ b/ prefixes, so every user config that would
+// change that contract is pinned: core.quotePath (path escaping),
+// diff.mnemonicPrefix / diff.noprefix / diff.srcPrefix / diff.dstPrefix
+// (header prefixes; the src/dst keys are ignored by git < 2.45), --no-color
+// (color.diff=always colors piped output too), --no-textconv (line numbers
+// must match the raw blob we parse, not a textconv rendering).
 //
-//   default:  git diff           — unstaged: working tree vs index
-//   --staged: git diff --cached  — staged:   index vs HEAD
-//   --base R: git diff R         — working tree vs ref R
+//	default:  git diff           — unstaged: working tree vs index
+//	--staged: git diff --cached  — staged:   index vs HEAD
+//	--base R: git diff R --      — working tree vs ref R
 func changedDiffArgs(staged bool, base string) ([]string, string, error) {
-	common := []string{"-c", "core.quotePath=false", "diff", "--no-ext-diff", "--find-renames"}
+	common := []string{
+		"-c", "core.quotePath=false",
+		"-c", "diff.mnemonicPrefix=false",
+		"-c", "diff.noprefix=false",
+		"-c", "diff.srcPrefix=a/",
+		"-c", "diff.dstPrefix=b/",
+		"diff", "--no-ext-diff", "--no-color", "--no-textconv", "--find-renames",
+	}
 	switch {
 	case staged && base != "":
 		return nil, "", fmt.Errorf("--staged and --base are mutually exclusive")
@@ -381,7 +410,8 @@ func changedDiffArgs(staged bool, base string) ([]string, string, error) {
 			// parsing the working tree as "new" would misattribute. Out of scope.
 			return nil, "", fmt.Errorf("--base takes a single ref, not a range (%q)", base)
 		}
-		return append(common, base), base, nil
+		// Trailing "--" disambiguates the ref from a same-named file.
+		return append(common, base, "--"), base, nil
 	default:
 		return common, "working tree", nil
 	}
@@ -418,52 +448,81 @@ func parseChangedFiles(diff string) []changedFile {
 			flush()
 			cur = &changedFile{OldLines: map[int]bool{}, NewLines: map[int]bool{}}
 			inHunk = false
+		case strings.HasPrefix(line, "diff --cc "), strings.HasPrefix(line, "diff --combined "):
+			// Combined diff (merge conflict): not analyzable as a two-side diff.
+			// Flush and absorb the whole block; RunE counts these for a warning.
+			flush()
+			inHunk = false
 		case cur == nil:
 			// preamble before the first file header
-		case strings.HasPrefix(line, "Binary files "):
-			cur.Binary = true
-			inHunk = false
-		case strings.HasPrefix(line, "--- "):
-			cur.OldPath = diffPathSide(strings.TrimPrefix(line, "--- "))
-			inHunk = false
-		case strings.HasPrefix(line, "+++ "):
-			cur.NewPath = diffPathSide(strings.TrimPrefix(line, "+++ "))
-			inHunk = false
 		case strings.HasPrefix(line, "@@"):
 			if o, n, ok := parseHunkStarts(line); ok {
 				oldLine, newLine = o, n
 				inHunk = true
 			}
-		case !inHunk:
-			// metadata between header and first hunk (index, mode, rename …)
-		case strings.HasPrefix(line, "\\"):
-			// "\ No newline at end of file"
-		case strings.HasPrefix(line, "+"):
-			if newLine > 0 {
-				cur.NewLines[newLine] = true
+		case inHunk:
+			// Hunk body lines are matched before the header prefixes: a deleted
+			// line whose content starts with "-- " renders as "--- ..." (and an
+			// added "++ " as "+++ ..."), which must count as a changed line, not
+			// reopen the file header — headers only occur before the first hunk.
+			switch {
+			case strings.HasPrefix(line, "\\"):
+				// "\ No newline at end of file"
+			case strings.HasPrefix(line, "+"):
+				if newLine > 0 {
+					cur.NewLines[newLine] = true
+				}
+				newLine++
+			case strings.HasPrefix(line, "-"):
+				if oldLine > 0 {
+					cur.OldLines[oldLine] = true
+				}
+				oldLine++
+			default:
+				// context line (leading space) or blank
+				oldLine++
+				newLine++
 			}
-			newLine++
-		case strings.HasPrefix(line, "-"):
-			if oldLine > 0 {
-				cur.OldLines[oldLine] = true
-			}
-			oldLine++
+		case strings.HasPrefix(line, "Binary files "):
+			cur.Binary = true
+		case strings.HasPrefix(line, "--- "):
+			cur.OldPath = diffPathSide(strings.TrimPrefix(line, "--- "))
+		case strings.HasPrefix(line, "+++ "):
+			cur.NewPath = diffPathSide(strings.TrimPrefix(line, "+++ "))
 		default:
-			// context line (leading space) or blank
-			oldLine++
-			newLine++
+			// metadata between header and first hunk (index, mode, rename …)
 		}
 	}
 	flush()
 	return files
 }
 
+// countConflictBlocks counts combined-diff file blocks ("diff --cc"/"diff
+// --combined"), which git emits for unmerged paths mid-conflict. They cannot be
+// attributed as a two-side diff, so `changed` surfaces them as a warning
+// instead of silently ignoring them.
+func countConflictBlocks(diff string) int {
+	n := 0
+	for _, line := range strings.Split(diff, "\n") {
+		if strings.HasPrefix(line, "diff --cc ") || strings.HasPrefix(line, "diff --combined ") {
+			n++
+		}
+	}
+	return n
+}
+
 // diffPathSide decodes one side of a diff file header: it un-C-quotes the path
 // (git escapes tabs, quotes, backslashes, and — without core.quotePath=false —
 // high bytes), maps /dev/null to "", and strips the a/ or b/ prefix. It must
-// not trim surrounding whitespace, which can be part of a filename.
+// not trim surrounding whitespace, which can be part of a filename — except
+// exactly one trailing tab, which git appends as a header/annotation separator
+// when the (unquoted) filename contains a space; a filename containing a real
+// tab is always C-quoted, so the quoted form never carries a separator tab.
 func diffPathSide(p string) string {
 	p = strings.TrimSuffix(p, "\r")
+	if !strings.HasPrefix(p, `"`) {
+		p = strings.TrimSuffix(p, "\t")
+	}
 	if strings.HasPrefix(p, `"`) {
 		if dec, err := strconv.Unquote(p); err == nil {
 			p = dec
@@ -557,24 +616,39 @@ func parseBlobSymbols(src []byte, path string) ([]symbols.Symbol, bool) {
 // class), deduplicated by name. Function-local declarations are skipped so a
 // change inside a body is attributed to the function, not a local on that line.
 func innermostChanged(syms []symbols.Symbol, lines map[int]bool) []symbols.Symbol {
-	seen := map[string]bool{}
-	var out []symbols.Symbol
+	if len(lines) == 0 {
+		return nil
+	}
+	sorted := make([]int, 0, len(lines))
 	for line := range lines {
-		var best *symbols.Symbol
-		for i := range syms {
-			s := &syms[i]
-			if !isChangedUnit(s.Kind, s.Depth) {
-				continue
-			}
-			if s.StartLine <= line && line <= s.EndLine {
-				if best == nil || (s.EndLine-s.StartLine) < (best.EndLine-best.StartLine) {
-					best = s
-				}
+		sorted = append(sorted, line)
+	}
+	sort.Ints(sorted)
+
+	// Per changed line, the most specific containing definition. Visiting only
+	// the changed lines inside each symbol's range (binary search into the
+	// sorted lines) avoids the O(lines × symbols) scan on huge rewrites.
+	best := make(map[int]*symbols.Symbol, len(sorted))
+	for i := range syms {
+		s := &syms[i]
+		if !isChangedUnit(s.Kind, s.Depth) {
+			continue
+		}
+		for j := sort.SearchInts(sorted, s.StartLine); j < len(sorted) && sorted[j] <= s.EndLine; j++ {
+			line := sorted[j]
+			if b := best[line]; b == nil || (s.EndLine-s.StartLine) < (b.EndLine-b.StartLine) {
+				best[line] = s
 			}
 		}
-		if best != nil && !seen[best.Name] {
-			seen[best.Name] = true
-			out = append(out, *best)
+	}
+
+	seen := map[string]bool{}
+	var out []symbols.Symbol
+	for _, line := range sorted {
+		s := best[line]
+		if s != nil && !seen[s.Name] {
+			seen[s.Name] = true
+			out = append(out, *s)
 		}
 	}
 	return out

--- a/cmd/changed_test.go
+++ b/cmd/changed_test.go
@@ -109,6 +109,133 @@ Binary files a/logo.png and b/logo.png differ
 	}
 }
 
+// A deleted line whose content starts with "-- " renders in the diff as
+// "--- ..." (hunk marker + content), and an added "++ " line as "+++ ...".
+// These are hunk body lines and must never be parsed as file headers — doing
+// so clobbers the paths and silently drops the rest of the hunk. Lua hits this
+// on every deleted comment; any language hits it via block-comment content.
+func TestParseChangedFilesHunkContentNotMistakenForHeaders(t *testing.T) {
+	diff := `diff --git a/p.lua b/p.lua
+index abc..def 100644
+--- a/p.lua
++++ b/p.lua
+@@ -1,6 +1,6 @@
+ local x = 1
+--- old comment
++-- new comment
+ local y = 2
+-function alpha() end
++function alpha() return 1 end
+diff --git a/q.go b/q.go
+index abc..def 100644
+--- a/q.go
++++ b/q.go
+@@ -1,3 +1,2 @@
+ package q
+-/* ++ emphasised ++ */
+ var V = 1
+`
+	files := parseChangedFiles(diff)
+	if len(files) != 2 {
+		t.Fatalf("parsed %d files, want 2: %+v", len(files), files)
+	}
+	lua := files[0]
+	if lua.OldPath != "p.lua" || lua.NewPath != "p.lua" {
+		t.Errorf("lua paths = (%q, %q), want (p.lua, p.lua) — header clobbered by hunk content", lua.OldPath, lua.NewPath)
+	}
+	if got, want := sortedInts(lua.OldLines), []int{2, 4}; !reflect.DeepEqual(got, want) {
+		t.Errorf("lua old lines = %v, want %v (comment deletion and later change both tracked)", got, want)
+	}
+	if got, want := sortedInts(lua.NewLines), []int{2, 4}; !reflect.DeepEqual(got, want) {
+		t.Errorf("lua new lines = %v, want %v", got, want)
+	}
+	goFile := files[1]
+	if goFile.OldPath != "q.go" || goFile.NewPath != "q.go" {
+		t.Errorf("go paths = (%q, %q), want (q.go, q.go) — header clobbered by '++' content", goFile.OldPath, goFile.NewPath)
+	}
+	if got, want := sortedInts(goFile.OldLines), []int{2}; !reflect.DeepEqual(got, want) {
+		t.Errorf("go old lines = %v, want %v", got, want)
+	}
+}
+
+// Combined-diff blocks (merge conflicts) must be absorbed without corrupting
+// neighbouring files, and counted for the warning.
+func TestParseChangedFilesAbsorbsCombinedDiffBlocks(t *testing.T) {
+	diff := `diff --cc conflicted.go
+index c105347,810f6e5..0000000
+--- a/conflicted.go
++++ b/conflicted.go
+@@@ -1,3 -1,3 +1,7 @@@
+  package p
+++<<<<<<< HEAD
+ +func A() int { return 1 }
+++=======
++ func A() int { return 2 }
+++>>>>>>> other
+diff --git a/clean.go b/clean.go
+index abc..def 100644
+--- a/clean.go
++++ b/clean.go
+@@ -1,2 +1,3 @@
+ package p
++var V = 1
+`
+	files := parseChangedFiles(diff)
+	if len(files) != 1 {
+		t.Fatalf("parsed %d files, want 1 (combined block absorbed): %+v", len(files), files)
+	}
+	if files[0].NewPath != "clean.go" {
+		t.Errorf("surviving file = %q, want clean.go", files[0].NewPath)
+	}
+	if got, want := sortedInts(files[0].NewLines), []int{2}; !reflect.DeepEqual(got, want) {
+		t.Errorf("clean.go new lines = %v, want %v", got, want)
+	}
+	if got := countConflictBlocks(diff); got != 1 {
+		t.Errorf("countConflictBlocks = %d, want 1", got)
+	}
+}
+
+// Pure renames and mode-only changes produce diff blocks with no ---/+++
+// headers and no hunks; they carry no content change and must not be reported
+// as "no parseable symbols" skips.
+func TestParseChangedFilesPureRenameAndModeOnly(t *testing.T) {
+	diff := `diff --git a/ren.go b/renamed.go
+similarity index 100%
+rename from ren.go
+rename to renamed.go
+diff --git a/script.sh b/script.sh
+old mode 100644
+new mode 100755
+`
+	for _, f := range parseChangedFiles(diff) {
+		if f.Binary || f.OldPath != "" || f.NewPath != "" || len(f.OldLines) != 0 || len(f.NewLines) != 0 {
+			t.Errorf("rename/mode-only block should parse to an empty entry, got %+v", f)
+		}
+	}
+}
+
+func TestChangedDiffArgsPinsOutputContract(t *testing.T) {
+	args, label, err := changedDiffArgs(false, "main")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if label != "main" {
+		t.Errorf("label = %q, want main", label)
+	}
+	joined := strings.Join(args, " ")
+	for _, want := range []string{
+		"core.quotePath=false", "diff.mnemonicPrefix=false", "diff.noprefix=false",
+		"--no-color", "--no-textconv",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("diff args missing %q: %v", want, args)
+		}
+	}
+	if args[len(args)-1] != "--" || args[len(args)-2] != "main" {
+		t.Errorf("base ref must be followed by \"--\" to disambiguate from paths: %v", args)
+	}
+}
+
 func TestDiffPathSideDecodesQuotedAndStripsPrefix(t *testing.T) {
 	cases := map[string]string{
 		"a/foo.go":          "foo.go",
@@ -117,6 +244,9 @@ func TestDiffPathSideDecodesQuotedAndStripsPrefix(t *testing.T) {
 		`"b/with space.go"`: "with space.go",
 		`"a/tab\there.go"`:  "tab\there.go",
 		"a/b/keep.go":       "b/keep.go", // only the leading a/ is stripped
+		// git appends a tab separator after unquoted names containing a space;
+		// a name with a real tab is always C-quoted, so this trim is safe.
+		"a/my file.go\t": "my file.go",
 	}
 	for in, want := range cases {
 		if got := diffPathSide(in); got != want {

--- a/cmd/graph_render.go
+++ b/cmd/graph_render.go
@@ -135,6 +135,9 @@ func mergeGraphResults(graphs ...*index.GraphResult) *index.GraphResult {
 		if g.Truncated > 0 {
 			merged.Truncated += g.Truncated
 		}
+		if g.EdgesTruncated {
+			merged.EdgesTruncated = true
+		}
 		for _, n := range g.Nodes {
 			if !seenNodes[n.ID] {
 				seenNodes[n.ID] = true
@@ -188,6 +191,11 @@ func renderAsGraph(cmd *cobra.Command, dbPath string, symbols []string, directio
 	depth := graphDepthOrDefault(cmd, graphDefaultDepth)
 	includeUnresolved, _ := cmd.Flags().GetBool("include-unresolved")
 	scope := resolveScopeFlag(cmd)
+	// Only impact defines --no-tests; on other verbs the lookup returns false.
+	noTests := false
+	if cmd.Flags().Lookup("no-tests") != nil {
+		noTests, _ = cmd.Flags().GetBool("no-tests")
+	}
 
 	graphs := make([]*index.GraphResult, 0, len(symbols))
 	rootIDs := make(map[string]bool, len(symbols))
@@ -198,6 +206,7 @@ func renderAsGraph(cmd *cobra.Command, dbPath string, symbols []string, directio
 			Depth:             depth,
 			IncludeUnresolved: includeUnresolved,
 			ResolveScope:      scope,
+			NoTests:           noTests,
 		}
 		g, err := index.BuildGraph(dbPath, q)
 		if err != nil {
@@ -490,7 +499,7 @@ func renderGraphMermaid(graph *index.GraphResult) string {
 	}
 	for _, edge := range graph.Edges {
 		arrow := "-->"
-		if !edge.Resolved {
+		if !edge.Resolved || edge.Indirect {
 			arrow = "-.->"
 		}
 		fmt.Fprintf(&b, "  %s %s %s\n", edge.From, arrow, edge.To)
@@ -509,7 +518,7 @@ func renderGraphDOT(graph *index.GraphResult) string {
 	}
 	for _, edge := range graph.Edges {
 		attrs := ""
-		if !edge.Resolved {
+		if !edge.Resolved || edge.Indirect {
 			attrs = " [style=dashed]"
 		}
 		fmt.Fprintf(&b, "  %s -> %s%s;\n", edge.From, edge.To, attrs)

--- a/cmd/impact.go
+++ b/cmd/impact.go
@@ -57,7 +57,6 @@ Examples:
 		if err != nil {
 			return err
 		}
-		_ = labelMap // attached to meta below
 		if len(merged) == 0 {
 			if len(names) == 1 {
 				return fmt.Errorf("no callers found for '%s'", names[0])

--- a/cmd/investigate.go
+++ b/cmd/investigate.go
@@ -46,17 +46,26 @@ Examples:
 			return err
 		}
 
-		if jsonOut && len(names) > 1 {
-			var all []any
+		if jsonOut {
+			// One object shape for any symbol count (matching trace/impact):
+			// an envelope with the requested symbols and one entry per symbol,
+			// each carrying its own "symbol" key so consumers don't have to
+			// correlate by array order.
+			results := make([]map[string]any, 0, len(names))
 			for _, name := range names {
 				entry, _ := findSymbolEntry(plan, name)
 				data := investigateOne(entry.Path, name, scope)
+				data["symbol"] = name
 				if label := entry.Label(); label != "" {
 					data["worktree"] = label
 				}
-				all = append(all, data)
+				results = append(results, data)
 			}
-			return writeJSON(all)
+			return writeJSON(map[string]any{
+				"symbols":       names,
+				"resolve_scope": string(index.NormalizeScope(scope)),
+				"results":       results,
+			})
 		}
 
 		for i, name := range names {
@@ -64,7 +73,7 @@ Examples:
 				fmt.Println()
 			}
 			entry, _ := findSymbolEntry(plan, name)
-			if err := investigateOnePrint(entry.Path, name, jsonOut, entry.Label(), scope); err != nil {
+			if err := investigateOnePrint(entry.Path, name, false, entry.Label(), scope); err != nil {
 				fmt.Fprintf(os.Stderr, "%s: %v\n", name, err)
 			}
 		}

--- a/cmd/trace.go
+++ b/cmd/trace.go
@@ -51,6 +51,9 @@ Examples:
 		ensureFresh(plan.Primary)
 		jsonOut := getJSONFlag(cmd)
 		depth, _ := cmd.Flags().GetInt("depth")
+		// Report the depth the BFS actually traverses, not the raw flag —
+		// the store clamps to [1, 5] (and defaults non-positive to 3).
+		depth = index.ClampTraceDepth(depth)
 		limit, _ := cmd.Flags().GetInt("limit")
 		kindsRaw, _ := cmd.Flags().GetString("kinds")
 		kinds := parseKindsFlag(kindsRaw)
@@ -79,7 +82,6 @@ Examples:
 
 		opts := index.TraceOptions{IncludeUnresolved: includeUnresolved, Scope: scope}
 		merged, sourceMap, labelMap, totalRaw, truncated, err := mergeTracePlan(plan, names, depth, limit, kinds, opts)
-		_ = labelMap
 		if err != nil {
 			return err
 		}

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -379,6 +379,9 @@ references: 39 (8 production, 31 test) in 12 (4 production, 8 test)
   name (several definitions) is flagged via `definition_count` / `definitions`.
 - `--no-tests` drops test-file callers; classification happens during traversal,
   so test callers never consume the `--limit` budget ahead of production ones.
+  In `--graph` mode, hidden test nodes are contracted: a production caller
+  reachable only through a test helper stays connected to the seed via a dashed
+  edge marked `"indirect": true` in the JSON.
 
 ```sh
 # only the production callers worth inspecting

--- a/index/classify.go
+++ b/index/classify.go
@@ -45,8 +45,8 @@ var ambiguousDirSegments = []string{
 var lowerTestSuffixes = []string{
 	"_test.go", "_test.py", "_test.rb", "_test.exs", "_test.ex",
 	"_spec.rb",
-	".test.ts", ".test.tsx", ".test.js", ".test.jsx", ".test.mjs",
-	".spec.ts", ".spec.tsx", ".spec.js", ".spec.jsx", ".spec.mjs",
+	".test.ts", ".test.tsx", ".test.js", ".test.jsx", ".test.mjs", ".test.cjs", ".test.mts", ".test.cts",
+	".spec.ts", ".spec.tsx", ".spec.js", ".spec.jsx", ".spec.mjs", ".spec.cjs", ".spec.mts", ".spec.cts",
 }
 
 // camelTestSuffixes are CamelCase class-filename conventions (Java/Kotlin/C#/
@@ -54,17 +54,21 @@ var lowerTestSuffixes = []string{
 // "Manifest.cs" do not false-match.
 var camelTestSuffixes = []string{
 	"Test.java", "Tests.java", "IT.java", "ITCase.java",
-	"Test.kt", "Tests.kt",
+	"Test.kt", "Tests.kt", "Spec.kt",
 	"Test.cs", "Tests.cs",
 	"Test.scala", "Spec.scala",
+	"Test.php",
 }
 
-// ClassifyPath returns the PathClass for a repo-relative file path. The index
-// stores rel paths with "/" separators; callers should pass those directly.
+// ClassifyPath returns the PathClass for a repo-relative file path. Windows
+// backslash separators are normalized here: the walker stores rel paths in
+// native form, and every anchored pattern below assumes "/" — without this,
+// classification silently reports everything as production on Windows.
 func ClassifyPath(relPath string) PathClass {
 	if relPath == "" {
 		return PathClassUnknown
 	}
+	relPath = strings.ReplaceAll(relPath, "\\", "/")
 	p := strings.ToLower(relPath)
 	base := p
 	baseOrig := relPath
@@ -86,7 +90,7 @@ func ClassifyPath(relPath string) PathClass {
 			return PathClassTest
 		}
 	}
-	if base == "conftest.py" {
+	if base == "conftest.py" || base == "tests.py" {
 		return PathClassTest
 	}
 	if (strings.HasPrefix(base, "test_")) &&

--- a/index/classify_test.go
+++ b/index/classify_test.go
@@ -25,6 +25,25 @@ func TestClassifyPath(t *testing.T) {
 		{"internal/index/testdata/sample.go", PathClassTest},
 		{"e2e/login.ts", PathClassTest},
 		{"tests/helpers.rb", PathClassTest},
+		// Module-flavoured JS/TS test extensions, PHPUnit, Kotest, Django.
+		{"src/util.test.cjs", PathClassTest},
+		{"src/util.spec.mts", PathClassTest},
+		{"src/Service/OrderServiceTest.php", PathClassTest},
+		{"src/main/kotlin/OrderSpec.kt", PathClassTest},
+		{"app/tests.py", PathClassTest},
+		{"polls/tests.py", PathClassTest},
+
+		// Windows rel paths (the walker stores native separators): anchoring
+		// must survive backslashes, and the bare-convention guard ("Test.java"
+		// with no class-name prefix is production) must not invert.
+		{`tests\helpers.rb`, PathClassTest},
+		{`spec\models\user.rb`, PathClassTest},
+		{`__tests__\render.js`, PathClassTest},
+		{`src\test\java\com\x\Foo.java`, PathClassTest},
+		{`pkg\foo\bar_test.go`, PathClassTest},
+		{`nested\dir\conftest.py`, PathClassTest},
+		{`src\Test.java`, PathClassProduction},
+		{`lib\Contestant.go`, PathClassProduction},
 
 		// False-positive guards: production code that merely contains
 		// "test"/"spec" as a substring must NOT be classified as test.

--- a/index/graph.go
+++ b/index/graph.go
@@ -70,6 +70,11 @@ type GraphQuery struct {
 	// single sentinel node is appended to make truncation visible.
 	// The root symbol is always kept. Zero means no cap.
 	Limit int
+	// NoTests contracts test-classified symbol nodes out of the graph — the
+	// graph analog of impact's hide-but-traverse: the test node is removed,
+	// and callers reachable only through it stay connected to its targets via
+	// synthesized indirect edges (see GraphEdge.Indirect). The root is exempt.
+	NoTests bool
 }
 
 type GraphNode struct {
@@ -84,7 +89,7 @@ type GraphNode struct {
 	// resolution is name-only, distinct same-named symbols collapse into this
 	// single node; the annotation lets a consumer see the conflation and
 	// investigate each definition. Both are omitted unless count > 1.
-	DefinitionCount int              `json:"definition_count,omitempty"`
+	DefinitionCount int               `json:"definition_count,omitempty"`
 	Definitions     []GraphDefinition `json:"definitions,omitempty"`
 }
 
@@ -100,6 +105,10 @@ type GraphEdge struct {
 	To       string        `json:"to"`
 	Kind     GraphEdgeKind `json:"kind"`
 	Resolved bool          `json:"resolved"`
+	// Indirect marks a contracted edge: From reaches To through one or more
+	// hidden intermediate nodes (e.g. test callers removed by NoTests), not by
+	// a direct call. Rendered dashed like unresolved edges.
+	Indirect bool `json:"indirect,omitempty"`
 }
 
 type GraphUnresolved struct {
@@ -117,6 +126,10 @@ type GraphResult struct {
 	// Truncated reports how many nodes were dropped by the Limit cap.
 	// Zero when no truncation happened.
 	Truncated int `json:"truncated,omitempty"`
+	// EdgesTruncated reports that the underlying trace/impact row fetch hit
+	// its internal cap, so the graph is incomplete even if no node-limit
+	// truncation happened (Truncated == 0).
+	EdgesTruncated bool `json:"edges_truncated,omitempty"`
 	// ResolveScope is the active cross-language resolution scope (down/trace
 	// direction). Empty when not applicable (e.g. importer/impls graphs).
 	ResolveScope ResolveScope `json:"resolve_scope,omitempty"`
@@ -207,6 +220,7 @@ func (s *Store) BuildGraph(q GraphQuery) (*GraphResult, error) {
 	}
 
 	builder := newGraphBuilder(q, metas)
+	edgesTruncated := false
 	if graphDirectionIncludesDown(q.Direction) {
 		// Always collect unresolved callees so GraphResult.Unresolved
 		// diagnostics are populated regardless of q.IncludeUnresolved;
@@ -214,7 +228,7 @@ func (s *Store) BuildGraph(q GraphQuery) (*GraphResult, error) {
 		// rendered. UnresolvedExemptFromLimit makes the 1000 cap bound only
 		// resolved traversal breadth, so external/scope-filtered calls don't
 		// crowd it out — the unresolved diagnostics themselves are not capped.
-		rows, err := s.FindTraceWithOptions(q.Symbol, q.Depth, 1000, TraceOptions{
+		rows, truncated, err := s.findTraceWithOptions(q.Symbol, q.Depth, graphEdgeRowCap, TraceOptions{
 			IncludeUnresolved:         true,
 			UnresolvedExemptFromLimit: true,
 			Scope:                     q.ResolveScope,
@@ -222,6 +236,7 @@ func (s *Store) BuildGraph(q GraphQuery) (*GraphResult, error) {
 		if err != nil {
 			return nil, err
 		}
+		edgesTruncated = edgesTruncated || truncated
 		builder.addTraceRows(rows)
 	}
 
@@ -234,22 +249,32 @@ func (s *Store) BuildGraph(q GraphQuery) (*GraphResult, error) {
 				langs = scopeLanguagesUnion(seedLangs, q.ResolveScope)
 			}
 		}
-		rows, err := s.FindImpactInLangs(q.Symbol, langs, q.Depth, 1000)
+		rows, truncated, err := s.findImpactInLangs(q.Symbol, langs, q.Depth, graphEdgeRowCap, false)
 		if err != nil {
 			return nil, err
 		}
+		edgesTruncated = edgesTruncated || truncated
 		builder.addImpactRows(rows)
 	}
 	builder.addRoot()
 
 	result := builder.result()
+	if q.NoTests {
+		result = contractTestNodes(result, graphNodeID(q.Symbol))
+	}
 	if q.Limit > 0 && len(result.Nodes) > q.Limit {
 		result = truncateByDegree(result, q.Limit, graphNodeID(q.Symbol))
 	}
-	// Set last so it survives builder.result and truncation.
+	// Set last so they survive builder.result, contraction, and truncation.
 	result.ResolveScope = NormalizeScope(q.ResolveScope)
+	result.EdgesTruncated = edgesTruncated
 	return result, nil
 }
+
+// graphEdgeRowCap bounds the underlying trace/impact row fetch per direction.
+// When the cap is hit, GraphResult.EdgesTruncated reports the graph as
+// incomplete rather than truncating silently.
+const graphEdgeRowCap = 1000
 
 func normalizeGraphQuery(q GraphQuery) GraphQuery {
 	if q.Depth <= 0 {
@@ -517,6 +542,106 @@ func truncateByDegree(g *GraphResult, limit int, rootID string) *GraphResult {
 		Edges:      filteredEdges,
 		Unresolved: filteredUnresolved,
 		Truncated:  dropped,
+	}
+}
+
+// contractTestNodes removes test-classified symbol nodes from a graph while
+// preserving connectivity — the graph analog of impact's --no-tests
+// hide-but-traverse semantics. Dropping a test node outright would orphan a
+// production caller whose only path to the seed runs through a test helper, so
+// each edge into a dropped node is rewired to that node's surviving targets as
+// an Indirect edge. A node is contracted only when its definition file
+// classifies confidently as test (unknown/ambiguous stay), and the root never
+// is. A direct edge between two survivors always wins over a synthesized one.
+func contractTestNodes(g *GraphResult, rootID string) *GraphResult {
+	drop := map[string]bool{}
+	for _, n := range g.Nodes {
+		if n.ID == rootID || n.Kind != GraphNodeKindSymbol {
+			continue
+		}
+		if n.Path != "" && ClassifyPath(n.Path) == PathClassTest {
+			drop[n.ID] = true
+		}
+	}
+	if len(drop) == 0 {
+		return g
+	}
+
+	out := map[string][]string{}
+	for _, e := range g.Edges {
+		out[e.From] = append(out[e.From], e.To)
+	}
+	// survivingTargets walks forward from a dropped node, through any chain of
+	// dropped nodes (cycle-safe), to the surviving nodes it ultimately reaches.
+	survivingTargets := func(start string) []string {
+		var targets []string
+		seen := map[string]bool{}
+		visited := map[string]bool{start: true}
+		queue := []string{start}
+		for len(queue) > 0 {
+			id := queue[0]
+			queue = queue[1:]
+			for _, to := range out[id] {
+				switch {
+				case drop[to]:
+					if !visited[to] {
+						visited[to] = true
+						queue = append(queue, to)
+					}
+				case !seen[to]:
+					seen[to] = true
+					targets = append(targets, to)
+				}
+			}
+		}
+		return targets
+	}
+
+	edges := map[string]GraphEdge{}
+	edgeKey := func(from, to string) string { return from + "|" + to }
+	for _, e := range g.Edges {
+		if !drop[e.From] && !drop[e.To] {
+			edges[edgeKey(e.From, e.To)] = e
+		}
+	}
+	for _, e := range g.Edges {
+		if drop[e.From] || !drop[e.To] {
+			continue
+		}
+		for _, t := range survivingTargets(e.To) {
+			if t == e.From {
+				continue // recursion through a hidden node: no self-edge
+			}
+			if k := edgeKey(e.From, t); edges[k].From == "" {
+				edges[k] = GraphEdge{From: e.From, To: t, Kind: e.Kind, Resolved: true, Indirect: true}
+			}
+		}
+	}
+
+	kept := make([]GraphNode, 0, len(g.Nodes)-len(drop))
+	for _, n := range g.Nodes {
+		if !drop[n.ID] {
+			kept = append(kept, n)
+		}
+	}
+	unresolved := make([]GraphUnresolved, 0, len(g.Unresolved))
+	for _, u := range g.Unresolved {
+		if !drop[u.From] {
+			unresolved = append(unresolved, u)
+		}
+	}
+
+	return &GraphResult{
+		Nodes: kept,
+		Edges: mapValuesSorted(edges, func(a, b GraphEdge) bool {
+			if a.From != b.From {
+				return a.From < b.From
+			}
+			return a.To < b.To
+		}),
+		Unresolved:   unresolved,
+		Truncated:    g.Truncated,
+		ResolveScope: g.ResolveScope,
 	}
 }
 

--- a/index/graph_test.go
+++ b/index/graph_test.go
@@ -558,3 +558,94 @@ func TestBuildGraphImpactSameNameCallerSurvivesExclude(t *testing.T) {
 		t.Fatalf("expected resolved Caller->Target impact edge, got %+v", g.Edges)
 	}
 }
+
+// NoTests must contract test-classified caller nodes out of the impact graph
+// with hide-but-traverse semantics: the test node disappears, a production
+// caller reachable only through it stays connected via an Indirect edge, and
+// direct production edges are untouched.
+func TestBuildGraphNoTestsContractsTestCallers(t *testing.T) {
+	store, _ := newTestStore(t)
+	now := time.Now()
+
+	appID, _ := store.UpsertFile("/repo/app/app.go", "app/app.go", "go", "h1", now, 100)
+	if err := store.InsertSymbols(appID, []symbols.Symbol{
+		{Name: "Target", Kind: "function", File: "/repo/app/app.go", StartLine: 1, EndLine: 10, Language: "go"},
+		{Name: "Direct", Kind: "function", File: "/repo/app/app.go", StartLine: 11, EndLine: 20, Language: "go"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.InsertRefs(appID, []symbols.Ref{
+		{Name: "Target", Line: 12, Language: "go", Kind: symbols.RefKindCall}, // Direct -> Target
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	testID, _ := store.UpsertFile("/repo/tests/helper_test.go", "tests/helper_test.go", "go", "h2", now, 100)
+	if err := store.InsertSymbols(testID, []symbols.Symbol{
+		{Name: "RunScenario", Kind: "function", File: "/repo/tests/helper_test.go", StartLine: 1, EndLine: 10, Language: "go"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.InsertRefs(testID, []symbols.Ref{
+		{Name: "Target", Line: 2, Language: "go", Kind: symbols.RefKindCall}, // RunScenario -> Target
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	mainID, _ := store.UpsertFile("/repo/app/main.go", "app/main.go", "go", "h3", now, 100)
+	if err := store.InsertSymbols(mainID, []symbols.Symbol{
+		{Name: "Main", Kind: "function", File: "/repo/app/main.go", StartLine: 1, EndLine: 10, Language: "go"},
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.InsertRefs(mainID, []symbols.Ref{
+		{Name: "RunScenario", Line: 2, Language: "go", Kind: symbols.RefKindCall}, // Main -> RunScenario
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Baseline: without NoTests the test caller is a normal node.
+	g, err := store.BuildGraph(GraphQuery{Symbol: "Target", Direction: GraphDirectionUp, Depth: 3})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !graphHasNode(g, "RunScenario") {
+		t.Fatalf("baseline graph should contain the test caller, got %+v", g.Nodes)
+	}
+
+	g, err = store.BuildGraph(GraphQuery{Symbol: "Target", Direction: GraphDirectionUp, Depth: 3, NoTests: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if graphHasNode(g, "RunScenario") {
+		t.Fatalf("NoTests graph must not contain the test caller, got %+v", g.Nodes)
+	}
+	if !graphHasNode(g, "Main") || !graphHasNode(g, "Direct") {
+		t.Fatalf("production callers must survive contraction, got %+v", g.Nodes)
+	}
+	var mainEdge, directEdge *GraphEdge
+	for i := range g.Edges {
+		e := &g.Edges[i]
+		if e.From == graphNodeID("Main") && e.To == graphNodeID("Target") {
+			mainEdge = e
+		}
+		if e.From == graphNodeID("Direct") && e.To == graphNodeID("Target") {
+			directEdge = e
+		}
+	}
+	if mainEdge == nil || !mainEdge.Indirect || !mainEdge.Resolved {
+		t.Fatalf("Main must reach Target via a resolved Indirect edge, got %+v", g.Edges)
+	}
+	if directEdge == nil || directEdge.Indirect {
+		t.Fatalf("Direct's edge must stay a plain direct edge, got %+v", g.Edges)
+	}
+}
+
+func graphHasNode(g *GraphResult, symbol string) bool {
+	for _, n := range g.Nodes {
+		if n.ID == graphNodeID(symbol) {
+			return true
+		}
+	}
+	return false
+}

--- a/index/scope_test.go
+++ b/index/scope_test.go
@@ -23,13 +23,13 @@ func TestScopeLanguages(t *testing.T) {
 		scope ResolveScope
 		want  []string // sorted; nil means unrestricted
 	}{
-		{"", ResolveScopeFamily, nil},      // empty seed -> unrestricted
-		{"go", ResolveScopeAll, nil},       // all -> unrestricted
+		{"", ResolveScopeFamily, nil}, // empty seed -> unrestricted
+		{"go", ResolveScopeAll, nil},  // all -> unrestricted
 		{"go", ResolveScopeSame, []string{"go"}},
 		{"kotlin", ResolveScopeSame, []string{"kotlin"}},
 		{"kotlin", ResolveScopeFamily, []string{"java", "kotlin", "scala"}},
 		{"typescript", ResolveScopeFamily, []string{"javascript", "tsx", "typescript"}},
-		{"go", ResolveScopeFamily, []string{"go"}},      // no family -> self
+		{"go", ResolveScopeFamily, []string{"go"}},       // no family -> self
 		{"cobol", ResolveScopeFamily, []string{"cobol"}}, // unknown -> self
 		{"go", "", []string{"go"}},                       // empty scope normalizes to family
 	}

--- a/index/store.go
+++ b/index/store.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -1540,6 +1541,19 @@ func (s *Store) FindTrace(symbolName string, depth, limit int, kinds ...string) 
 	return s.FindTraceWithOptions(symbolName, depth, limit, TraceOptions{}, kinds...)
 }
 
+// ClampTraceDepth normalizes a requested depth to the value the trace BFS
+// actually uses: [1, 5], defaulting to 3 for a non-positive request. Exported
+// so the CLI reports the effective depth rather than echoing the raw flag.
+func ClampTraceDepth(depth int) int {
+	if depth <= 0 {
+		return 3
+	}
+	if depth > 5 {
+		return 5
+	}
+	return depth
+}
+
 // FindTraceWithOptions is FindTrace with explicit control over filtering behavior.
 func (s *Store) FindTraceWithOptions(symbolName string, depth, limit int, opts TraceOptions, kinds ...string) ([]TraceResult, error) {
 	results, _, err := s.findTraceWithOptions(symbolName, depth, limit, opts, kinds...)
@@ -1548,23 +1562,17 @@ func (s *Store) FindTraceWithOptions(symbolName string, depth, limit int, opts T
 
 // findTraceWithOptions is the trace BFS core; the bool reports whether the
 // per-query limit truncated the result set. Truncation is detected by
-// over-fetching one row past the limit, then trimming — but only on the normal
-// path. The graph builder exempts unresolved rows from the limit
-// (UnresolvedExemptFromLimit), where len(results) legitimately exceeds limit, so
-// it is neither over-fetched nor trimmed.
+// over-fetching one budget-consuming row past the limit, then trimming that
+// row. Under UnresolvedExemptFromLimit (the graph builder) only resolved rows
+// consume budget, so len(results) may legitimately exceed limit; the
+// over-fetched row is still the last appended one, so the trim stays exact.
 func (s *Store) findTraceWithOptions(symbolName string, depth, limit int, opts TraceOptions, kinds ...string) ([]TraceResult, bool, error) {
-	if depth <= 0 {
-		depth = 3
-	}
-	if depth > 5 {
-		depth = 5
-	}
-	// Over-fetch one past the limit to detect truncation — but only on the
-	// normal path with a positive limit. The graph builder exempts unresolved
-	// rows (UnresolvedExemptFromLimit) and must not be trimmed; a non-positive
-	// limit keeps its prior store-level meaning (no normalization here, so
-	// direct callers are unaffected — the package wrapper does its own clamp).
-	overfetch := !opts.UnresolvedExemptFromLimit && limit > 0
+	depth = ClampTraceDepth(depth)
+	// Over-fetch one budget-consuming row past the limit to detect truncation.
+	// A non-positive limit keeps its prior store-level meaning (no
+	// normalization here, so direct callers are unaffected — the package
+	// wrapper does its own clamp).
+	overfetch := limit > 0
 	budget := limit
 	if overfetch {
 		budget = limit + 1
@@ -1650,6 +1658,7 @@ func (s *Store) findTraceWithOptions(symbolName string, depth, limit int, opts T
 	}
 
 	seen := make(map[string]bool)
+	queriedLocs := map[string]bool{}
 	var results []TraceResult
 	// limited counts results that consume the limit budget. It equals
 	// len(results) unless unresolved rows are exempted (see TraceOptions),
@@ -1658,6 +1667,9 @@ func (s *Store) findTraceWithOptions(symbolName string, depth, limit int, opts T
 	// The seed is resolved across all languages; callees are then constrained
 	// to their caller's resolution scope below.
 	currentLocs := resolveSymbol(symbolName, nil)
+	for _, loc := range currentLocs {
+		queriedLocs[loc.file+"\x00"+strconv.Itoa(loc.startLine)+"\x00"+loc.name] = true
+	}
 
 	for d := 1; d <= depth && len(currentLocs) > 0 && limited < budget; d++ {
 		var nextLocs []symLoc
@@ -1690,9 +1702,16 @@ func (s *Store) findTraceWithOptions(symbolName string, depth, limit int, opts T
 				results = append(results, tr)
 
 				// Only resolved callees expand the frontier; unresolved ones
-				// are terminal leaves (nextSymLocs is empty).
+				// are terminal leaves (nextSymLocs is empty). Dedupe enqueued
+				// locations: a callee reached from several callers (or again
+				// at a later depth) yields identical callee rows, all already
+				// dropped by seen — re-querying it is wasted SQL.
 				for _, nextLoc := range nextSymLocs {
-					nextLocs = append(nextLocs, nextLoc)
+					lk := nextLoc.file + "\x00" + strconv.Itoa(nextLoc.startLine) + "\x00" + nextLoc.name
+					if !queriedLocs[lk] {
+						queriedLocs[lk] = true
+						nextLocs = append(nextLocs, nextLoc)
+					}
 				}
 
 				// Unresolved leaves don't consume the budget when exempted, so
@@ -1702,8 +1721,10 @@ func (s *Store) findTraceWithOptions(symbolName string, depth, limit int, opts T
 					if limited >= budget {
 						if overfetch {
 							// We collected one past the limit, so a further
-							// callee genuinely exists: report truncation.
-							return results[:limit], true, nil
+							// callee genuinely exists: drop the over-fetched
+							// row (the one just appended) and report
+							// truncation.
+							return results[:len(results)-1], true, nil
 						}
 						return results, false, nil
 					}
@@ -1815,6 +1836,10 @@ func (s *Store) findImpactInLangs(symbolName string, langs []string, depth, limi
 	fetchTarget := limit + 1
 
 	seen := make(map[string]bool)
+	// queried dedupes the BFS frontier by caller name: re-querying a name at a
+	// later depth (reached via a different file) returns the same ref rows,
+	// all already dropped by seen — pure wasted SQL on hot symbols.
+	queried := map[string]bool{symbolName: true}
 	var results []ImpactResult
 	currentSymbols := []string{symbolName}
 
@@ -1852,7 +1877,10 @@ func (s *Store) findImpactInLangs(symbolName string, langs []string, depth, limi
 
 				// Traverse through the caller regardless, so production code
 				// behind a (hidden) test caller is still discovered.
-				nextSymbols = append(nextSymbols, caller)
+				if !queried[caller] {
+					queried[caller] = true
+					nextSymbols = append(nextSymbols, caller)
+				}
 
 				if noTests && ClassifyPath(relPath) == PathClassTest {
 					continue


### PR DESCRIPTION
## Summary

- What changed? Fixes from a post-merge audit of the v0.14 triage features (production/test classification, `--no-tests`, exact reference counts, `cymbal changed`). No new features: every change corrects a defect in already-merged behaviour, each with a regression test. Three commits: `changed` diff-parser hardening, Windows/convention fixes in path classification, and graph/reporting honesty (`--no-tests --graph`, truncation and depth reporting, stable `investigate --json`).
- Why is this needed? Each issue was verified empirically against real git output or a fixture repo; several are silent-wrong-answer bugs (dropped changed symbols, empty results under common git config, classification disabled on Windows, a flag silently ignored).

## Details

### `cymbal changed`: diff parser hardening (commit 1)

- **In-hunk content misparsed as file headers (the big one).** The parser checked `--- `/`+++ ` header prefixes before hunk-body lines, so a deleted line whose content starts with `-- ` renders as `--- ...` and was treated as a file header: it clobbered the file's paths and silently dropped the rest of the hunk's changed symbols. Every deleted Lua comment triggers this, and any language can via block-comment content. Hunk-body lines now match first (git only emits headers before a file's first hunk).
- **Filenames containing spaces were silently skipped.** Git appends a tab separator after unquoted header paths containing a space (`--- a/my file.go\t`, verified byte-for-byte); the kept tab made both blob reads fail and the file was miscounted as "no parseable symbols". Exactly one trailing tab is stripped: safe, because a name with a real tab is always C-quoted.
- **User git config could silently empty all results.** `diff.mnemonicPrefix=true`, `diff.noprefix`, `diff.srcPrefix`/`dstPrefix`, `color.diff=always` (ANSI escapes even when piped), and textconv drivers each break the output contract the parser assumes, producing "No changed symbols found" with no error. The invocation now pins all of them (`-c` overrides plus `--no-color --no-textconv`), the same way `core.quotePath` was already pinned.
- **Real `git diff` failures surfaced as false clean results.** A failure without stderr (or a non-exit error) was swallowed and the run proceeded on empty output. Any error now aborts.
- Pure renames and mode-only changes no longer count toward the misleading "no parseable symbols" warning; merge-conflict combined-diff blocks (previously invisible) are absorbed safely, counted, and warned about (`conflicted_files` in JSON); `--base <ref>` passes `--` so a file named like the ref cannot break git; `--json` emits `"results": []` instead of `null`; and symbol attribution on huge rewrites drops its lines-times-symbols scan for a binary search with deterministic output order.

### Path classification (commit 2)

- **Classification was silently broken on Windows**, a shipped release target. The walker stores rel paths with native separators, but every anchored pattern assumed `/`: `--no-tests` hid nothing, the production/test splits counted test code as production, search ranking's test-file penalty never applied, and the bare-convention guard inverted (`src\Test.java` classified as test while `tests\helpers.rb` did not). `ClassifyPath` now normalizes backslashes before matching.
- Added conventions the original sweep missed: `.test`/`.spec` on `.cjs`/`.mts`/`.cts`, PHPUnit `*Test.php`, Kotest `*Spec.kt`, and Django `tests.py`.

### Graph and reporting honesty (commit 3)

- **`impact <sym> --no-tests --graph` silently ignored `--no-tests`.** The graph path never read the flag, so test callers a user asked to exclude were rendered anyway. Test-classified nodes are now contracted out of the graph with the BFS's hide-but-traverse intent: each edge into a dropped test node is rewired to the node's surviving targets as a synthesized edge marked `"indirect": true` (dashed in mermaid/dot), so a production caller reachable only through a test helper is neither hidden nor orphaned. The root is exempt, only confidently-test nodes are contracted, and a direct edge always wins over a synthesized one.
- **Graph edge fetches truncated silently.** Row fetches are capped at 1000 per direction; a dense graph could render incomplete while the text output for the same query said `truncated: true`. The trace core's over-fetch truncation detection now also covers the graph's unresolved-exempt mode, and `GraphResult` gains `edges_truncated`.
- **`trace` echoed the raw `--depth` flag** while the BFS clamps to [1, 5]; `--depth 10` reported `depth: 10` but traversed 5. It now reports the effective depth (exported `index.ClampTraceDepth`, mirroring impact's `ClampImpactBounds`).
- **BREAKING: `investigate --json` shape is now stable.** It emitted an object for one symbol and a bare array for several, so piped `--stdin` batches flipped shape based on how many names survived dedup: exactly the inconsistency the v0.14 `trace`/`impact` change eliminated. It now always emits `{symbols, resolve_scope, results}`, and every per-symbol entry carries its own `symbol` key (previously only error entries did). This completes the JSON-shape decision v0.14 already made.
- Performance: both BFS cores re-queried duplicate frontier entries (a caller reached via several files, or a callee reached from several callers); results were already deduplicated, so this was pure wasted SQL on hot symbols. Frontiers are now deduped.

## Testing

- Commands run:
  - `make ci` (build-check, `go vet`, `go test ./...`, govulncheck), green throughout
- Extra validation:
  - Built the binary and drove a fixture repo end to end, including hostile git config (`diff.mnemonicPrefix=true`, `color.diff=always`): the Lua comment-deletion case, the spaced filename, `--no-tests --graph` contraction (baseline vs contracted, dashed indirect edge), the depth clamp report, and the stable investigate envelope, plus edge probes (empty diff, pure rename, file named like the base ref, bad ref)

## Checklist

- [x] I ran the required checks locally, or I explained why I could not in the Testing section.
- [x] I reviewed the diff for unrelated, generated, or vendored changes.
- [x] I updated docs, benchmarks, or release notes when behavior changed, or I explained why no updates were needed.
- [x] I filled out the Security Notes and Risks / Rollout sections below.

## Security Notes

- User input, file parsing, shell execution, or network behavior touched: `cymbal changed` parses git diff output and invokes `git diff`/`git cat-file` as subprocesses; this PR tightens that surface (pins config-dependent output, treats subprocess failure as an error, and keeps the existing ref-argument guards, now with a `--` separator). No network behavior.
- New dependencies or vendored code added: none.
- Secrets, credentials, or tokens touched: none.
- Follow-up needed: none.

## Risks / Rollout

- Risk level: low. One deliberate breaking change (`investigate --json` envelope, called out above and in the changelog); everything else fixes silent misbehaviour and is covered by regression tests.
- Rollback plan: revert the three commits; they are independent of each other and of any schema change (no index format bump).
