### PR TITLE
parser: index arrow function assignments and hook-wrapped bindings

### DIFF
--- a/cmd/show.go
+++ b/cmd/show.go
@@ -34,6 +34,7 @@ multiple reads in a single turn.
 
 Examples:
   cymbal show ParseFile                        # show symbol source
+  cymbal show App.handleSave                   # show nested symbol by qualified name
   cymbal show store.go:SearchSymbols           # show symbol, narrowed by file hint
   cymbal show internal/index/store.go          # show full file
   cymbal show internal/index/store.go:80-120   # show lines 80-120

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -2472,8 +2472,14 @@ func jsSignatureNode(node *sitter.Node) *sitter.Node {
 }
 
 // jsUnwrapToFunction returns the arrow_function or function node from a value,
-// unwrapping a call_expression wrapper (useCallback/useMemo/etc.) if present.
-// Only unwraps call_expressions with a bare identifier callee.
+// unwrapping call_expression wrappers (useCallback/useMemo/memo(forwardRef(...))
+// and similar) when the wrapped function is the FIRST argument. Restricting to
+// the first argument keeps utility calls that take trailing callbacks
+// (sortBy(items, fn), fetchWithRetry(url, cb)) from being misread as function
+// definitions. Only call_expressions with a bare identifier callee are
+// unwrapped (not member expressions like arr.map or obj.on). Known accepted
+// noise: first-argument-callback calls (setTimeout(fn, ms)) and useMemo of a
+// plain value still classify as functions.
 func jsUnwrapToFunction(node *sitter.Node) *sitter.Node {
 	switch node.Kind() {
 	case "arrow_function", "function", "function_expression":
@@ -2487,11 +2493,15 @@ func jsUnwrapToFunction(node *sitter.Node) *sitter.Node {
 		if args == nil {
 			return nil
 		}
+		// Find the first real argument (skipping punctuation and comments)
+		// and unwrap it recursively, so memo(forwardRef((props, ref) => ...))
+		// resolves to the inner function.
 		for i := range int(args.ChildCount()) {
 			arg := args.Child(uint(i))
-			if arg.Kind() == "arrow_function" || arg.Kind() == "function" || arg.Kind() == "function_expression" {
-				return arg
+			if !arg.IsNamed() || arg.Kind() == "comment" {
+				continue
 			}
+			return jsUnwrapToFunction(arg)
 		}
 	}
 	return nil

--- a/parser/parser.go
+++ b/parser/parser.go
@@ -984,7 +984,8 @@ func (e *symbolExtractor) classifyPythonInner(nodeType string, node *sitter.Node
 func (e *symbolExtractor) classifyJS(nodeType string, node *sitter.Node) (string, *sitter.Node) {
 	switch nodeType {
 	case "function_declaration", "class_declaration", "interface_declaration",
-		"type_alias_declaration", "enum_declaration", "lexical_declaration":
+		"type_alias_declaration", "enum_declaration", "lexical_declaration",
+		"variable_declaration":
 		// Skip if parent is export_statement — the parent already emits this symbol.
 		if node.Parent() != nil && node.Parent().Kind() == "export_statement" {
 			return "", nil
@@ -1017,19 +1018,29 @@ func (e *symbolExtractor) classifyJSInner(nodeType string, node *sitter.Node) (s
 		return "type", node.ChildByFieldName("name")
 	case "enum_declaration":
 		return "enum", node.ChildByFieldName("name")
-	case "lexical_declaration":
+	case "lexical_declaration", "variable_declaration":
 		for i := range int(node.ChildCount()) {
 			child := node.Child(uint(i))
 			if child.Kind() == "variable_declarator" {
 				nameNode := child.ChildByFieldName("name")
 				valueNode := child.ChildByFieldName("value")
-				if valueNode != nil && (valueNode.Kind() == "arrow_function" || valueNode.Kind() == "function") {
+				if valueNode != nil && jsValueIsFunction(valueNode) {
 					return "function", nameNode
 				}
 			}
 		}
 	}
 	return "", nil
+}
+
+// jsValueIsFunction reports whether a variable_declarator's value node
+// represents a function definition. Matches direct arrow functions/function
+// expressions, and also call_expression wrappers (useCallback, useMemo, etc.)
+// whose first argument is an arrow function or function expression.
+// Only matches call_expressions with a bare identifier callee (not member
+// expressions like arr.map or obj.on) to avoid false positives.
+func jsValueIsFunction(node *sitter.Node) bool {
+	return jsUnwrapToFunction(node) != nil
 }
 
 func (e *symbolExtractor) classifyRust(nodeType string, node *sitter.Node) (string, *sitter.Node) {
@@ -2450,15 +2461,40 @@ func jsSignatureNode(node *sitter.Node) *sitter.Node {
 			child := node.Child(uint(i))
 			if child.Kind() == "variable_declarator" {
 				if val := child.ChildByFieldName("value"); val != nil {
-					switch val.Kind() {
-					case "arrow_function", "function":
-						return val
+					if fn := jsUnwrapToFunction(val); fn != nil {
+						return fn
 					}
 				}
 			}
 		}
 	}
 	return node
+}
+
+// jsUnwrapToFunction returns the arrow_function or function node from a value,
+// unwrapping a call_expression wrapper (useCallback/useMemo/etc.) if present.
+// Only unwraps call_expressions with a bare identifier callee.
+func jsUnwrapToFunction(node *sitter.Node) *sitter.Node {
+	switch node.Kind() {
+	case "arrow_function", "function", "function_expression":
+		return node
+	case "call_expression":
+		callee := node.ChildByFieldName("function")
+		if callee == nil || callee.Kind() != "identifier" {
+			return nil
+		}
+		args := node.ChildByFieldName("arguments")
+		if args == nil {
+			return nil
+		}
+		for i := range int(args.ChildCount()) {
+			arg := args.Child(uint(i))
+			if arg.Kind() == "arrow_function" || arg.Kind() == "function" || arg.Kind() == "function_expression" {
+				return arg
+			}
+		}
+	}
+	return nil
 }
 
 func (e *symbolExtractor) extractSignature(node *sitter.Node, kind string) string {

--- a/parser/parser_feature_test.go
+++ b/parser/parser_feature_test.go
@@ -2668,3 +2668,119 @@ export const Button = (label: string): JSX.Element => <button>{label}</button>
 		}
 	}
 }
+
+func TestFeatureTSUseCallbackIndexed(t *testing.T) {
+	src := []byte(`import { useCallback, useMemo } from 'react'
+
+export function AssetPage() {
+    const handleSave = useCallback(async (data: FormData) => {
+        await api.save(data)
+    }, [api])
+
+    const parseErrors = (response: unknown): string[] => {
+        return []
+    }
+
+    const sortRows = useMemo(() => (rows: Row[]) => rows.sort(), [])
+
+    const compute = useMemo(function computeInner(x: number) {
+        return x * 2
+    }, [])
+
+    return null
+}
+`)
+	result, err := ParseSource(src, "AssetPage.tsx", "tsx", lang.Default.TreeSitter("tsx"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name       string
+		wantKind   string
+		wantParent string
+	}{
+		{"AssetPage", "function", ""},
+		{"handleSave", "function", "AssetPage"},
+		{"parseErrors", "function", "AssetPage"},
+		{"sortRows", "function", "AssetPage"},
+		{"compute", "function", "AssetPage"},
+	}
+	for _, tc := range cases {
+		sym := findSymbolKind(result.Symbols, tc.name, tc.wantKind)
+		if sym == nil {
+			debugParseResult(t, result)
+			t.Fatalf("expected to find %s (%s)", tc.name, tc.wantKind)
+		}
+		if sym.Parent != tc.wantParent {
+			t.Errorf("%s: parent=%q, want %q", tc.name, sym.Parent, tc.wantParent)
+		}
+	}
+
+	// Verify signatures are extracted through the call wrapper.
+	handleSave := findSymbol(result.Symbols, "handleSave")
+	if handleSave.Signature == "" {
+		t.Error("handleSave: signature is empty")
+	} else if !strings.Contains(handleSave.Signature, "data: FormData") {
+		t.Errorf("handleSave: signature %q missing parameter info", handleSave.Signature)
+	}
+}
+
+func TestFeatureTSLetVarArrowFunctions(t *testing.T) {
+	src := []byte(`let handler = (e: Event) => {
+    e.preventDefault()
+}
+
+var legacy = () => doThing()
+`)
+	result, err := ParseSource(src, "test.ts", "typescript", lang.Default.TreeSitter("typescript"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	handler := findSymbolKind(result.Symbols, "handler", "function")
+	if handler == nil {
+		debugParseResult(t, result)
+		t.Fatal("expected to find handler as function")
+	}
+
+	legacy := findSymbolKind(result.Symbols, "legacy", "function")
+	if legacy == nil {
+		debugParseResult(t, result)
+		t.Fatal("expected to find legacy as function")
+	}
+}
+
+func TestFeatureJSUseCallbackNotIndexedWithoutArrowArg(t *testing.T) {
+	// A call expression that does NOT contain an arrow/function arg should
+	// not produce a symbol.
+	src := []byte(`const result = fetchData('/api/users')
+const config = Object.freeze({ key: 'value' })
+`)
+	result, err := ParseSource(src, "test.ts", "typescript", lang.Default.TreeSitter("typescript"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, sym := range result.Symbols {
+		t.Errorf("unexpected symbol: %s (%s)", sym.Name, sym.Kind)
+	}
+}
+
+func TestFeatureJSMemberCallWithCallbackNotIndexed(t *testing.T) {
+	// Member-expression calls (arr.map, emitter.on, etc.) that take callback
+	// args must NOT produce symbols, even though they contain arrow functions.
+	src := []byte(`const doubled = arr.map((x) => x * 2)
+const sub = emitter.on('click', () => { cleanup() })
+const filtered = items.filter((item) => item.active)
+const result = Promise.all([1,2,3].map(async (n) => fetch(n)))
+`)
+	result, err := ParseSource(src, "test.ts", "typescript", lang.Default.TreeSitter("typescript"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, sym := range result.Symbols {
+		t.Errorf("unexpected symbol: %s (%s) - false positive from callback arg", sym.Name, sym.Kind)
+	}
+}

--- a/parser/parser_feature_test.go
+++ b/parser/parser_feature_test.go
@@ -2751,7 +2751,7 @@ var legacy = () => doThing()
 	}
 }
 
-func TestFeatureJSUseCallbackNotIndexedWithoutArrowArg(t *testing.T) {
+func TestFeatureTSCallWithoutFunctionArgNotIndexed(t *testing.T) {
 	// A call expression that does NOT contain an arrow/function arg should
 	// not produce a symbol.
 	src := []byte(`const result = fetchData('/api/users')
@@ -2767,7 +2767,7 @@ const config = Object.freeze({ key: 'value' })
 	}
 }
 
-func TestFeatureJSMemberCallWithCallbackNotIndexed(t *testing.T) {
+func TestFeatureTSMemberCallWithCallbackNotIndexed(t *testing.T) {
 	// Member-expression calls (arr.map, emitter.on, etc.) that take callback
 	// args must NOT produce symbols, even though they contain arrow functions.
 	src := []byte(`const doubled = arr.map((x) => x * 2)
@@ -2782,5 +2782,77 @@ const result = Promise.all([1,2,3].map(async (n) => fetch(n)))
 
 	for _, sym := range result.Symbols {
 		t.Errorf("unexpected symbol: %s (%s) - false positive from callback arg", sym.Name, sym.Kind)
+	}
+}
+
+func TestFeatureTSTrailingCallbackNotIndexed(t *testing.T) {
+	// Only a FIRST-argument function unwraps; utility calls taking trailing
+	// callbacks are values, not function definitions.
+	src := []byte(`const sorted = sortBy(items, (x) => x.name)
+const result = fetchWithRetry(url, () => retry())
+`)
+	result, err := ParseSource(src, "test.ts", "typescript", lang.Default.TreeSitter("typescript"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, sym := range result.Symbols {
+		t.Errorf("unexpected symbol: %s (%s) - trailing callback must not classify as function", sym.Name, sym.Kind)
+	}
+}
+
+func TestFeatureTSFirstArgCallbackAcceptedNoise(t *testing.T) {
+	// Documented tradeoff: a first-argument callback (setTimeout) still
+	// classifies the binding as a function. Pin the behavior so a change is
+	// deliberate.
+	src := []byte(`const t = setTimeout(() => tick(), 100)
+`)
+	result, err := ParseSource(src, "test.ts", "typescript", lang.Default.TreeSitter("typescript"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if sym := findSymbolKind(result.Symbols, "t", "function"); sym == nil {
+		t.Fatal("expected t indexed as function (accepted first-arg-callback noise); if this changed deliberately, update jsUnwrapToFunction's doc comment")
+	}
+}
+
+func TestFeatureTSComposedWrapperIndexed(t *testing.T) {
+	// memo(forwardRef(fn)) unwraps recursively through first arguments.
+	src := []byte(`import { memo, forwardRef } from 'react'
+
+const FancyInput = memo(forwardRef((props: Props, ref: Ref) => null))
+`)
+	result, err := ParseSource(src, "FancyInput.tsx", "tsx", lang.Default.TreeSitter("tsx"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	sym := findSymbolKind(result.Symbols, "FancyInput", "function")
+	if sym == nil {
+		debugParseResult(t, result)
+		t.Fatal("expected FancyInput indexed as function through memo(forwardRef(...))")
+	}
+	if !strings.Contains(sym.Signature, "props") {
+		t.Errorf("FancyInput signature %q missing inner function params", sym.Signature)
+	}
+}
+
+func TestFeatureTSExportVarLetArrowIndexed(t *testing.T) {
+	src := []byte(`export var legacy = (a: number) => a * 2
+export let handler = () => {}
+`)
+	result, err := ParseSource(src, "test.ts", "typescript", lang.Default.TreeSitter("typescript"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if sym := findSymbolKind(result.Symbols, "legacy", "function"); sym == nil {
+		debugParseResult(t, result)
+		t.Fatal("expected exported var arrow function to be indexed")
+	}
+	if sym := findSymbolKind(result.Symbols, "handler", "function"); sym == nil {
+		debugParseResult(t, result)
+		t.Fatal("expected exported let arrow function to be indexed")
 	}
 }


### PR DESCRIPTION
## Summary

- Index `const`/`let`/`var` arrow function assignments as function symbols in JS/TS/TSX
- Index `useCallback()`/`useMemo()`/`memo()`/`forwardRef()` and other bare-identifier HOF wrappers that take a function as first argument
- Correctly nest these symbols under their parent function (shows in `outline` with proper indentation)
- Extract signatures through the call wrapper (e.g. `useCallback(async (data: FormData) => {...}, [])` reports signature `(data: FormData)`)
- Exclude member-expression calls (`arr.map`, `emitter.on`) to prevent false positives

## Test plan

- [x] `TestFeatureTSUseCallbackIndexed` - useCallback/useMemo wrapped and plain const arrows, verifies parent nesting and signature extraction
- [x] `TestFeatureTSLetVarArrowFunctions` - let/var arrow function bindings indexed
- [x] `TestFeatureJSUseCallbackNotIndexedWithoutArrowArg` - plain function calls don't produce spurious symbols
- [x] `TestFeatureJSMemberCallWithCallbackNotIndexed` - arr.map/emitter.on with callback args are NOT indexed
- [x] All existing JS/TS/TSX tests pass (no regressions)
- [x] Full test suite green

## Stacking note

**This PR is stacked on #69** (`fix/index-subdirectory-path`): its diff currently includes #69's `cmd/index.go` / `index/` / `walker/` commits. Once #69 merges, this branch will be rebased so only the parser changes remain.

## Audit follow-up (latest commit)

A post-review audit (multi-agent + Codex) tightened the heuristic:

- **First-argument only**: a `call_expression` now unwraps only when its *first* argument resolves to a function, so utility calls with trailing callbacks (`sortBy(items, fn)`, `fetchWithRetry(url, cb)`) no longer classify the binding as a function.
- **Composed wrappers**: the unwrap recurses through first arguments, so `memo(forwardRef((props, ref) => ...))` is now indexed with the inner function's signature.
- **Documented accepted noise**: first-argument callbacks (`setTimeout(fn, ms)`) and `useMemo` of a plain value still classify as functions; this is stated in the `jsUnwrapToFunction` comment and pinned by a test so any change is deliberate.
- Renamed the two TS-parsing tests that claimed "JS"; added `export var`/`export let` arrow-function coverage.
