### PR TITLE
fix: index --force <subdirectory> writes to correct DB

### DIFF
--- a/cmd/index.go
+++ b/cmd/index.go
@@ -13,7 +13,12 @@ import (
 var indexCmd = &cobra.Command{
 	Use:   "index [path]",
 	Short: "Index a directory for symbol discovery",
-	Long:  `Index a directory for symbol discovery.`,
+	Long: `Index a directory for symbol discovery.
+
+Pointing at a subdirectory of a git repo updates the repo's index in place,
+restricted to that subtree: files outside the subtree are neither reparsed
+nor pruned. Filter flags (--exclude, --include-*) on a subtree run apply to
+that run only; later query refreshes use the options from the last full index.`,
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		path := "."
@@ -29,6 +34,11 @@ var indexCmd = &cobra.Command{
 		if _, err := os.Stat(absPath); err != nil {
 			return fmt.Errorf("path not found: %s", absPath)
 		}
+		// Resolve symlinks so git-root detection (a lexical climb) sees the
+		// real location; otherwise a symlinked path gets an orphaned DB.
+		if resolved, err := filepath.EvalSymlinks(absPath); err == nil {
+			absPath = resolved
+		}
 
 		workers, _ := cmd.Flags().GetInt("workers")
 		force, _ := cmd.Flags().GetBool("force")
@@ -41,12 +51,9 @@ var indexCmd = &cobra.Command{
 		// the subdirectory as a scope.
 		repoRoot := absPath
 		var scope string
-		if gitRoot, gitErr := index.FindGitRoot(absPath); gitErr == nil {
-			gitRootAbs, _ := filepath.Abs(gitRoot)
-			if gitRootAbs != absPath {
-				repoRoot = gitRootAbs
-				scope = absPath
-			}
+		if gitRoot, gitErr := index.FindGitRoot(absPath); gitErr == nil && gitRoot != absPath {
+			repoRoot = gitRoot
+			scope = absPath
 		}
 
 		// Use --db flag > CYMBAL_DB env > compute from repo root.
@@ -59,6 +66,12 @@ var indexCmd = &cobra.Command{
 				if err != nil {
 					return fmt.Errorf("computing db path: %w", err)
 				}
+			}
+		}
+
+		if scope != "" && (len(excludes) > 0 || includeGenerated || includeLargeFiles) {
+			if _, err := os.Stat(dbPath); err == nil {
+				fmt.Fprintln(os.Stderr, "note: filter flags on a subtree index apply to this run only; later refreshes use the options from the last full index")
 			}
 		}
 

--- a/cmd/index.go
+++ b/cmd/index.go
@@ -36,13 +36,26 @@ var indexCmd = &cobra.Command{
 		includeGenerated, _ := cmd.Flags().GetBool("include-generated")
 		includeLargeFiles, _ := cmd.Flags().GetBool("include-large-files")
 
-		// Use --db flag > CYMBAL_DB env > compute from target path.
+		// Resolve the repo root for DB path computation. If absPath is a
+		// subdirectory of a git repo, use the repo root for the DB and pass
+		// the subdirectory as a scope.
+		repoRoot := absPath
+		var scope string
+		if gitRoot, gitErr := index.FindGitRoot(absPath); gitErr == nil {
+			gitRootAbs, _ := filepath.Abs(gitRoot)
+			if gitRootAbs != absPath {
+				repoRoot = gitRootAbs
+				scope = absPath
+			}
+		}
+
+		// Use --db flag > CYMBAL_DB env > compute from repo root.
 		dbPath, _ := cmd.Flags().GetString("db")
 		if dbPath == "" {
 			if p := os.Getenv("CYMBAL_DB"); p != "" {
 				dbPath = p
 			} else {
-				dbPath, err = index.RepoDBPath(absPath)
+				dbPath, err = index.RepoDBPath(repoRoot)
 				if err != nil {
 					return fmt.Errorf("computing db path: %w", err)
 				}
@@ -52,12 +65,13 @@ var indexCmd = &cobra.Command{
 		fmt.Fprintf(os.Stderr, "Indexing %s ...\n", absPath)
 		start := time.Now()
 
-		stats, err := index.Index(absPath, dbPath, index.Options{
+		stats, err := index.Index(repoRoot, dbPath, index.Options{
 			Workers:           workers,
 			Force:             force,
 			Exclude:           excludes,
 			IncludeGenerated:  includeGenerated,
 			IncludeLargeFiles: includeLargeFiles,
+			Scope:             scope,
 		})
 		if err != nil {
 			return fmt.Errorf("indexing failed: %w", err)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/1broseidon/cymbal
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/coder3101/tree-sitter-proto v0.0.0-20250826173151-a1fbf36c3029

--- a/index/index.go
+++ b/index/index.go
@@ -349,13 +349,21 @@ func Index(root, dbPath string, opts Options) (*Stats, error) {
 	}
 	defer store.Close()
 
-	// Only store repo root when indexing the full root (not a subtree).
+	// Store repo root in metadata. On scoped runs, set it only if absent
+	// (avoids overwriting with a subtree path, but ensures EnsureFresh works
+	// even if the first-ever index was scoped).
 	if opts.Scope == "" {
 		if err := store.SetMeta("repo_root", root); err != nil {
 			return nil, fmt.Errorf("setting repo metadata: %w", err)
 		}
 		if err := storeIndexOptions(store, opts); err != nil {
 			return nil, fmt.Errorf("setting index metadata: %w", err)
+		}
+	} else {
+		if existing, _ := store.GetMeta("repo_root"); existing == "" {
+			if err := store.SetMeta("repo_root", root); err != nil {
+				return nil, fmt.Errorf("setting repo metadata: %w", err)
+			}
 		}
 	}
 
@@ -366,6 +374,17 @@ func Index(root, dbPath string, opts Options) (*Stats, error) {
 	})
 	if err != nil {
 		return nil, fmt.Errorf("walking directory: %w", err)
+	}
+
+	// When walking a subtree, the walker computes RelPath relative to the
+	// walk path. Rebase to the repo root so stored rel_paths are consistent.
+	if opts.Scope != "" {
+		for i := range files {
+			rel, err := filepath.Rel(root, files[i].Path)
+			if err == nil {
+				files[i].RelPath = rel
+			}
+		}
 	}
 
 	// Load all stored mtime_ns + size in one query for fast skip checks.

--- a/index/index.go
+++ b/index/index.go
@@ -333,6 +333,15 @@ func Index(root, dbPath string, opts Options) (*Stats, error) {
 	walkPath := root
 	if opts.Scope != "" {
 		walkPath = canonicalPath(opts.Scope)
+		rel, err := filepath.Rel(root, walkPath)
+		if err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+			return nil, fmt.Errorf("scope %s is outside repo root %s", walkPath, root)
+		}
+		if rel == "." {
+			// Scope equals the root: treat as a full unscoped index.
+			opts.Scope = ""
+			walkPath = root
+		}
 	}
 
 	if dbPath == "" {
@@ -349,9 +358,10 @@ func Index(root, dbPath string, opts Options) (*Stats, error) {
 	}
 	defer store.Close()
 
-	// Store repo root in metadata. On scoped runs, set it only if absent
-	// (avoids overwriting with a subtree path, but ensures EnsureFresh works
-	// even if the first-ever index was scoped).
+	// Store repo root in metadata. A scoped run must not overwrite the
+	// stored options with its run-local filter flags, so it only writes
+	// metadata when the DB is brand new (repo_root absent) — that keeps
+	// EnsureFresh working even if the first-ever index was scoped.
 	if opts.Scope == "" {
 		if err := store.SetMeta("repo_root", root); err != nil {
 			return nil, fmt.Errorf("setting repo metadata: %w", err)
@@ -364,27 +374,22 @@ func Index(root, dbPath string, opts Options) (*Stats, error) {
 			if err := store.SetMeta("repo_root", root); err != nil {
 				return nil, fmt.Errorf("setting repo metadata: %w", err)
 			}
+			if err := storeIndexOptions(store, opts); err != nil {
+				return nil, fmt.Errorf("setting index metadata: %w", err)
+			}
 		}
 	}
 
+	// RelBase keeps RelPath (and exclude matching) repo-relative even when
+	// walking only a subtree.
 	files, walkStats, err := walker.WalkWithOptions(walkPath, workers, lang.Default.Supported, walker.WalkOptions{
 		Exclude:           opts.Exclude,
 		IncludeGenerated:  opts.IncludeGenerated,
 		IncludeLargeFiles: opts.IncludeLargeFiles,
+		RelBase:           root,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("walking directory: %w", err)
-	}
-
-	// When walking a subtree, the walker computes RelPath relative to the
-	// walk path. Rebase to the repo root so stored rel_paths are consistent.
-	if opts.Scope != "" {
-		for i := range files {
-			rel, err := filepath.Rel(root, files[i].Path)
-			if err == nil {
-				files[i].RelPath = rel
-			}
-		}
 	}
 
 	// Load all stored mtime_ns + size in one query for fast skip checks.

--- a/index/index.go
+++ b/index/index.go
@@ -32,6 +32,7 @@ type Options struct {
 	Exclude           []string
 	IncludeGenerated  bool
 	IncludeLargeFiles bool
+	Scope             string // if set, only index/prune files under this subtree
 }
 
 // Stats reports indexing results.
@@ -328,6 +329,12 @@ func Index(root, dbPath string, opts Options) (*Stats, error) {
 	}
 	root = canonicalPath(root)
 
+	// Determine the walk path: use Scope if set, otherwise root.
+	walkPath := root
+	if opts.Scope != "" {
+		walkPath = canonicalPath(opts.Scope)
+	}
+
 	if dbPath == "" {
 		var err error
 		dbPath, err = RepoDBPath(root)
@@ -342,15 +349,17 @@ func Index(root, dbPath string, opts Options) (*Stats, error) {
 	}
 	defer store.Close()
 
-	// Store repo root in metadata.
-	if err := store.SetMeta("repo_root", root); err != nil {
-		return nil, fmt.Errorf("setting repo metadata: %w", err)
-	}
-	if err := storeIndexOptions(store, opts); err != nil {
-		return nil, fmt.Errorf("setting index metadata: %w", err)
+	// Only store repo root when indexing the full root (not a subtree).
+	if opts.Scope == "" {
+		if err := store.SetMeta("repo_root", root); err != nil {
+			return nil, fmt.Errorf("setting repo metadata: %w", err)
+		}
+		if err := storeIndexOptions(store, opts); err != nil {
+			return nil, fmt.Errorf("setting index metadata: %w", err)
+		}
 	}
 
-	files, walkStats, err := walker.WalkWithOptions(root, workers, lang.Default.Supported, walker.WalkOptions{
+	files, walkStats, err := walker.WalkWithOptions(walkPath, workers, lang.Default.Supported, walker.WalkOptions{
 		Exclude:           opts.Exclude,
 		IncludeGenerated:  opts.IncludeGenerated,
 		IncludeLargeFiles: opts.IncludeLargeFiles,
@@ -366,11 +375,17 @@ func Index(root, dbPath string, opts Options) (*Stats, error) {
 	}
 
 	// Phase 0: prune stale files (deleted/renamed since last index).
+	// When scoped to a subtree, only prune files under that subtree.
 	currentPaths := make(map[string]struct{}, len(files))
 	for _, f := range files {
 		currentPaths[f.Path] = struct{}{}
 	}
-	staleRemoved, _ := store.DeleteStalePaths(currentPaths)
+	var staleRemoved int
+	if opts.Scope == "" {
+		staleRemoved, _ = store.DeleteStalePaths(currentPaths)
+	} else {
+		staleRemoved, _ = store.DeleteStalePathsUnder(walkPath, currentPaths)
+	}
 
 	// (parseResult is defined at package level)
 

--- a/index/index_feature_test.go
+++ b/index/index_feature_test.go
@@ -678,3 +678,96 @@ func TestFeatureIndexSubdirectoryScopePrunesOnlyWithinScope(t *testing.T) {
 		t.Error("expected NewServer (root file) to still be present after scoped reindex")
 	}
 }
+
+func TestFeatureIndexScopeOutsideRootRejected(t *testing.T) {
+	dir := createTestRepo(t)
+	outside := t.TempDir()
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	if _, err := Index(dir, dbPath, Options{Workers: 2, Scope: outside}); err == nil {
+		t.Fatal("expected error for scope outside repo root")
+	}
+}
+
+func TestFeatureIndexScopeEqualsRootActsUnscoped(t *testing.T) {
+	dir := createTestRepo(t)
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	if _, err := Index(dir, dbPath, Options{Workers: 2, Scope: dir, IncludeGenerated: true}); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := OpenStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	// Scope == root is normalized to a full index, so options are stored.
+	raw, err := store.GetMeta("index_include_generated")
+	if err != nil || raw != "true" {
+		t.Errorf("index_include_generated = %q, %v; want \"true\" (scope==root should act unscoped)", raw, err)
+	}
+}
+
+func TestFeatureFirstScopedIndexStoresOptions(t *testing.T) {
+	dir := createTestRepo(t)
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	subdir := filepath.Join(dir, "sub")
+	if err := os.MkdirAll(subdir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subdir, "helper.go"), []byte("package sub\nfunc SubHelper() {}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// First-ever index is scoped: repo_root AND options must be seeded so a
+	// later EnsureFresh completes the repo with the same options.
+	if _, err := Index(dir, dbPath, Options{Workers: 2, Scope: subdir, IncludeGenerated: true}); err != nil {
+		t.Fatal(err)
+	}
+
+	store, err := OpenStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	if root, err := store.GetMeta("repo_root"); err != nil || root == "" {
+		t.Errorf("repo_root = %q, %v; want non-empty on first scoped index", root, err)
+	}
+	if raw, err := store.GetMeta("index_include_generated"); err != nil || raw != "true" {
+		t.Errorf("index_include_generated = %q, %v; want \"true\" on first scoped index", raw, err)
+	}
+}
+
+func TestFeatureScopedExcludeIsRepoRelative(t *testing.T) {
+	dir := createTestRepo(t)
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	subdir := filepath.Join(dir, "sub")
+	if err := os.MkdirAll(subdir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subdir, "helper.go"), []byte("package sub\nfunc SubHelper() {}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Index(dir, dbPath, Options{Workers: 2}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Exclude patterns are repo-relative on scoped runs too: "sub/helper.go"
+	// must match even though the walk root is the subtree.
+	stats, err := Index(dir, dbPath, Options{Workers: 2, Force: true, Scope: subdir, Exclude: []string{"sub/helper.go"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.FilesExcluded != 1 {
+		t.Errorf("FilesExcluded = %d, want 1 (repo-relative pattern must match in scoped walk)", stats.FilesExcluded)
+	}
+	if stats.StaleRemoved != 1 {
+		t.Errorf("StaleRemoved = %d, want 1 (excluded file pruned from DB)", stats.StaleRemoved)
+	}
+}

--- a/index/index_feature_test.go
+++ b/index/index_feature_test.go
@@ -539,3 +539,136 @@ func TestFeatureListReposUsesCacheDirOverride(t *testing.T) {
 		t.Fatalf("expected ListRepos to return %s from cache override, got %+v", dbPath, repos)
 	}
 }
+
+func TestFeatureIndexSubdirectoryScopeUsesCorrectDB(t *testing.T) {
+	dir := createTestRepo(t)
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	// Create a subdirectory with a file.
+	subdir := filepath.Join(dir, "sub")
+	if err := os.MkdirAll(subdir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	subFile := `package sub
+
+func SubHelper() string {
+    return "hello"
+}
+`
+	if err := os.WriteFile(filepath.Join(subdir, "helper.go"), []byte(subFile), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Index the full repo first.
+	stats1, err := Index(dir, dbPath, Options{Workers: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats1.FilesIndexed == 0 {
+		t.Fatal("expected files to be indexed")
+	}
+
+	// Now force-index only the subdirectory. This should update the same DB
+	// and NOT delete files outside the subdirectory.
+	stats2, err := Index(dir, dbPath, Options{Workers: 2, Force: true, Scope: subdir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats2.FilesIndexed != 1 {
+		t.Errorf("expected 1 file indexed in subdir, got %d", stats2.FilesIndexed)
+	}
+	// Files outside the scope should NOT be pruned.
+	if stats2.StaleRemoved != 0 {
+		t.Errorf("expected 0 stale removed (files outside scope preserved), got %d", stats2.StaleRemoved)
+	}
+
+	// Verify that symbols from the root are still present.
+	store, err := OpenStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	results, err := store.SearchSymbols("NewServer", "", "", true, false, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) == 0 {
+		t.Error("expected NewServer (from root) to still be in DB after subdir reindex")
+	}
+
+	results, err = store.SearchSymbols("SubHelper", "", "", true, false, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) == 0 {
+		t.Error("expected SubHelper (from subdir) to be in DB")
+	}
+}
+
+func TestFeatureIndexSubdirectoryScopePrunesOnlyWithinScope(t *testing.T) {
+	dir := createTestRepo(t)
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+
+	// Create a subdirectory with two files.
+	subdir := filepath.Join(dir, "pkg")
+	if err := os.MkdirAll(subdir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subdir, "a.go"), []byte("package pkg\nfunc A() {}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subdir, "b.go"), []byte("package pkg\nfunc B() {}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Index the full repo.
+	_, err := Index(dir, dbPath, Options{Workers: 2})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Delete one file in the subdir.
+	os.Remove(filepath.Join(subdir, "b.go"))
+
+	// Reindex only the subdir - should prune b.go but not touch root files.
+	stats, err := Index(dir, dbPath, Options{Workers: 2, Scope: subdir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if stats.StaleRemoved != 1 {
+		t.Errorf("expected 1 stale removed within scope, got %d", stats.StaleRemoved)
+	}
+
+	store, err := OpenStore(dbPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer store.Close()
+
+	// B should be gone.
+	results, err := store.SearchSymbols("B", "", "", true, false, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 0 {
+		t.Error("expected B to be pruned after deletion + scoped reindex")
+	}
+
+	// A and root-level symbols should still be there.
+	results, err = store.SearchSymbols("A", "", "", true, false, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) == 0 {
+		t.Error("expected A to still be present")
+	}
+
+	results, err = store.SearchSymbols("NewServer", "", "", true, false, 50)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) == 0 {
+		t.Error("expected NewServer (root file) to still be present after scoped reindex")
+	}
+}

--- a/index/index_feature_test.go
+++ b/index/index_feature_test.go
@@ -603,6 +603,12 @@ func SubHelper() string {
 	}
 	if len(results) == 0 {
 		t.Error("expected SubHelper (from subdir) to be in DB")
+	} else {
+		// rel_path must be relative to the repo root, not the walk scope.
+		want := filepath.Join("sub", "helper.go")
+		if results[0].RelPath != want {
+			t.Errorf("SubHelper rel_path = %q, want %q", results[0].RelPath, want)
+		}
 	}
 }
 

--- a/index/store.go
+++ b/index/store.go
@@ -279,6 +279,69 @@ func (s *Store) DeleteStalePaths(currentPaths map[string]struct{}) (int, error) 
 	return deleted, nil
 }
 
+// DeleteStalePathsUnder removes stored files that are under the given prefix
+// but not in currentPaths. Used when indexing a subtree to avoid pruning
+// files outside that subtree.
+func (s *Store) DeleteStalePathsUnder(prefix string, currentPaths map[string]struct{}) (int, error) {
+	stored, err := s.AllStoredPaths()
+	if err != nil {
+		return 0, err
+	}
+
+	pfx := prefix
+	if !strings.HasSuffix(pfx, string(filepath.Separator)) {
+		pfx += string(filepath.Separator)
+	}
+
+	var stale []string
+	for _, p := range stored {
+		if !strings.HasPrefix(p, pfx) {
+			continue
+		}
+		if _, ok := currentPaths[p]; !ok {
+			stale = append(stale, p)
+		}
+	}
+
+	if len(stale) == 0 {
+		return 0, nil
+	}
+
+	tx, err := s.db.Begin()
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback()
+
+	const batchSize = 100
+	deleted := 0
+	for i := 0; i < len(stale); i += batchSize {
+		end := i + batchSize
+		if end > len(stale) {
+			end = len(stale)
+		}
+		batch := stale[i:end]
+		placeholders := make([]string, len(batch))
+		args := make([]any, len(batch))
+		for j, p := range batch {
+			placeholders[j] = "?"
+			args[j] = p
+		}
+		q := "DELETE FROM files WHERE path IN (" + strings.Join(placeholders, ",") + ")"
+		res, err := tx.Exec(q, args...)
+		if err != nil {
+			return 0, err
+		}
+		n, _ := res.RowsAffected()
+		deleted += int(n)
+	}
+
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return deleted, nil
+}
+
 // HashFile computes SHA-256 of a file.
 func HashFile(path string) (string, error) {
 	data, err := os.ReadFile(path)

--- a/walker/walker.go
+++ b/walker/walker.go
@@ -32,6 +32,10 @@ type WalkOptions struct {
 	IncludeGenerated bool
 	// IncludeLargeFiles disables the default large-source-file skip rule.
 	IncludeLargeFiles bool
+	// RelBase, if set, is the base directory for RelPath computation and
+	// exclude matching instead of the walk root. Set it to the repo root
+	// when walking a subtree so paths stay repo-relative.
+	RelBase string
 }
 
 // WalkStats reports files omitted by walk-time path filters.
@@ -88,6 +92,10 @@ func Walk(root string, workers int, langFilter func(string) bool) ([]FileEntry, 
 func WalkWithOptions(root string, workers int, langFilter func(string) bool, opts WalkOptions) ([]FileEntry, WalkStats, error) {
 	if workers <= 0 {
 		workers = 8
+	}
+	relBase := opts.RelBase
+	if relBase == "" {
+		relBase = root
 	}
 
 	var mu sync.Mutex
@@ -147,7 +155,7 @@ func WalkWithOptions(root string, workers int, langFilter func(string) bool, opt
 			return nil
 		}
 
-		rel, err := filepath.Rel(root, path)
+		rel, err := filepath.Rel(relBase, path)
 		if err != nil {
 			rel = path
 		}


### PR DESCRIPTION
## Summary

- `cymbal index --force <subdirectory>` was silently writing to an orphaned DB (hashed from the subdirectory path instead of the git root), making the indexed data invisible to all query commands
- Now resolves the git root for DB path computation and passes the subdirectory as a `Scope` option
- Scoped indexing only walks/prunes files within the subtree, preserving the rest of the DB
- `rel_path` is rebased to the repo root after scoped walks (prevents path corruption in output)
- Seeds `repo_root` metadata on first scoped index so `ensureFresh` works later

## Test plan

- [x] `TestFeatureIndexSubdirectoryScopeUsesCorrectDB` - scoped reindex writes to same DB, preserves out-of-scope files, correct `rel_path`
- [x] `TestFeatureIndexSubdirectoryScopePrunesOnlyWithinScope` - deleted files within scope are pruned, files outside scope preserved
- [x] All existing index tests pass (stale pruning, force reindex, incremental skip, etc.)
- [x] Full test suite green

## Audit follow-up (second commit)

A post-review audit (multi-agent + Codex) surfaced three edge cases, fixed in the follow-up commit:

- **Symlinked targets**: `cymbal index /elsewhere/alias` (symlink into a repo subtree) still created an orphaned DB, because git-root detection climbs the path lexically. The target is now resolved with `EvalSymlinks` first.
- **Scope containment**: `index.Index` now rejects a `Scope` outside the canonical repo root (previously a symlinked scope could store `../` rel_paths and out-of-repo content). `Scope` equal to the root is normalized to a full unscoped index.
- **Filter-flag policy on scoped runs**: a first-ever scoped index now persists `--exclude`/`--include-*` options so the next auto-refresh completes the repo with the same flags; scoped runs over an existing DB print a note that filter flags are run-local (previously they were applied and then silently reverted by the next query's refresh). New `walker.WalkOptions.RelBase` keeps `rel_path` and exclude matching repo-relative on subtree walks, replacing the post-walk rebase loop.

- [x] New tests: scope-outside-root rejected, scope==root acts unscoped, first scoped index stores options, repo-relative excludes on scoped walks
- [x] Full test suite + `go vet` green
