### PR TITLE
build: bump go directive to 1.26.5 for stdlib vuln fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/1broseidon/cymbal
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/coder3101/tree-sitter-proto v0.0.0-20250826173151-a1fbf36c3029


### PR DESCRIPTION
## Summary

The CI `security` job (`make vulncheck`) currently fails on **every** branch, including `main` if re-run today: govulncheck flags [GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856) (Encrypted Client Hello privacy leak in `crypto/tls`), published to the vuln DB after main's last green run. cymbal genuinely reaches `crypto/tls` (e.g. the update checker's `http.Client.Do`), so the finding is *affected*, not just imported.

Fixed in go1.26.5. CI installs the toolchain via `go-version-file: go.mod`, so this one-line bump clears the job — same treatment as the previous 1.26.4 bump (caa8b00). The Dockerfile floats on `golang:1.26-bookworm` and needs no change.

Note: this same commit has also been merged into the #68 / #69 / #70 branches so their `security` checks are green in the meantime; since it is the identical one-line change, it drops out of their diffs as soon as this PR lands on `main`. Merging this PR is still what fixes `main` itself (and any future branch).

## Test plan

- [x] `make build-check` passes on go1.26.5
- [x] `make vulncheck` locally: "No vulnerabilities found"
- [x] CI fully green on this PR, including the `security` job
