### PR TITLE
show: document and improve file:Symbol scoped lookup

### DIFF
--- a/cmd/show.go
+++ b/cmd/show.go
@@ -15,12 +15,17 @@ import (
 )
 
 var showCmd = &cobra.Command{
-	Use:   "show <symbol|file[:L1-L2]> [symbol2 ...]",
+	Use:   "show <symbol|file[:L1-L2|:Symbol]> [symbol2 ...]",
 	Short: "Read source by symbol name or file path",
 	Long: `Show source code for a symbol or file.
 
-If the argument contains '/' or ends with a known extension, it's treated as a file path.
-Otherwise, it's treated as a symbol name.
+file.go:SymbolName looks up a symbol with a file hint: results are narrowed to
+files whose path ends with (or contains) the hint, which disambiguates common
+names (Handler, Config) without the qualified Parent.child syntax. If nothing
+matches the hint, the search falls back to global results.
+
+Otherwise, an argument containing '/' or ending with a known extension is
+treated as a file path; anything else is a symbol name.
 
 Multi-symbol mode: pass more than one symbol, or pipe newline-separated names
 via --stdin, and show will render each one under a "═══ <name> ═══" header.
@@ -29,6 +34,7 @@ multiple reads in a single turn.
 
 Examples:
   cymbal show ParseFile                        # show symbol source
+  cymbal show store.go:SearchSymbols           # show symbol, narrowed by file hint
   cymbal show internal/index/store.go          # show full file
   cymbal show internal/index/store.go:80-120   # show lines 80-120
   cymbal show Foo Bar Baz                      # batch: three symbols at once
@@ -196,6 +202,9 @@ func buildShowSymbolPayload(dbPath, name string, ctx int, showAll bool, includes
 	}
 	allResults := filterByPath(res.Results, func(r index.SymbolResult) string { return r.RelPath }, includes, excludes)
 	if len(allResults) == 0 {
+		if file, sym := parseSymbolArg(name); file != "" && len(res.Results) == 0 {
+			return nil, fmt.Errorf("symbol not found: %s (no match in %s or globally)", sym, file)
+		}
 		return nil, fmt.Errorf("symbol not found: %s", name)
 	}
 	displayResults := allResults
@@ -237,8 +246,11 @@ func buildShowSymbolPayload(dbPath, name string, ctx int, showAll bool, includes
 // isFilePath returns true if the target looks like a file path (not file:Symbol).
 func isFilePath(target string) bool {
 	if idx := strings.LastIndex(target, ":"); idx > 0 {
-		suffix := target[idx+1:]
-		if len(suffix) > 0 && suffix[0] != 'L' && (suffix[0] < '0' || suffix[0] > '9') {
+		// Only a numeric suffix (with optional leading L) is a line range;
+		// anything else — including symbols starting with L, like :Load —
+		// routes to symbol lookup.
+		rangeStr := strings.TrimPrefix(target[idx+1:], "L")
+		if len(rangeStr) == 0 || rangeStr[0] < '0' || rangeStr[0] > '9' {
 			return false
 		}
 		target = target[:idx]
@@ -427,6 +439,9 @@ func showSymbol(dbPath, name string, ctx int, jsonOut, showAll bool, includes, e
 
 	allResults := filterByPath(res.Results, func(r index.SymbolResult) string { return r.RelPath }, includes, excludes)
 	if len(allResults) == 0 {
+		if file, sym := parseSymbolArg(name); file != "" && len(res.Results) == 0 {
+			return fmt.Errorf("symbol not found: %s (no match in %s or globally)", sym, file)
+		}
 		return fmt.Errorf("symbol not found: %s", name)
 	}
 	displayResults := allResults

--- a/cmd/show_test.go
+++ b/cmd/show_test.go
@@ -9,6 +9,142 @@ import (
 	"github.com/1broseidon/cymbal/index"
 )
 
+func TestIsFilePathWithSymbolSuffix(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		// File paths (no colon or numeric suffix)
+		{"internal/store.go", true},
+		{"store.go", true},
+		{"store.go:80-120", true},
+		{"store.go:L80-L120", true},
+		// File:Symbol — should NOT be a file path (routes to symbol lookup)
+		{"store.go:SearchSymbols", false},
+		// Symbols starting with L must not be mistaken for line ranges
+		{"store.go:Load", false},
+		{"internal/store.go:ListFiles", false},
+		{"store.go:L", false},
+		{"internal/store.go:SearchSymbols", false},
+		{"parser.ts:extractRefs", false},
+		// Pure symbol names
+		{"SearchSymbols", false},
+		{"Store.SearchSymbols", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := isFilePath(tt.input)
+			if got != tt.want {
+				t.Errorf("isFilePath(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseSymbolArgFileScoped(t *testing.T) {
+	tests := []struct {
+		input    string
+		wantFile string
+		wantSym  string
+	}{
+		{"store.go:SearchSymbols", "store.go", "SearchSymbols"},
+		{"internal/index/store.go:SearchSymbols", "internal/index/store.go", "SearchSymbols"},
+		{"parser.ts:extractRefs", "parser.ts", "extractRefs"},
+		// Numeric suffix — not a symbol
+		{"store.go:80", "", "store.go:80"},
+		{"store.go:L80", "", "store.go:L80"},
+		// No colon — plain symbol
+		{"SearchSymbols", "", "SearchSymbols"},
+		// Dot-qualified — not file-scoped
+		{"Store.SearchSymbols", "", "Store.SearchSymbols"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			file, sym := parseSymbolArg(tt.input)
+			if file != tt.wantFile || sym != tt.wantSym {
+				t.Errorf("parseSymbolArg(%q) = (%q, %q), want (%q, %q)",
+					tt.input, file, sym, tt.wantFile, tt.wantSym)
+			}
+		})
+	}
+}
+
+func TestFlexResolveFileHintBehaviour(t *testing.T) {
+	defer index.CloseAll()
+
+	repoDir := t.TempDir()
+	mustWrite := func(rel, content string) {
+		t.Helper()
+		path := filepath.Join(repoDir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	mustWrite("alpha/dup.go", "package alpha\nfunc Dup() {}\n")
+	mustWrite("beta/dup.go", "package beta\nfunc Dup() {}\n")
+	mustWrite("delta/store.go", "package delta\nfunc Col() {}\n")
+	mustWrite("zeta/loader.go", "package zeta\nfunc Load() {}\n")
+	mustWrite("epsilon/mystore.go", "package epsilon\nfunc Col() {}\n")
+
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	if _, err := index.Index(repoDir, dbPath, index.Options{Workers: 1}); err != nil {
+		t.Fatal(err)
+	}
+
+	// The file hint wins when the name is defined in multiple files.
+	res, err := flexResolve(dbPath, "alpha/dup.go:Dup")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Results) != 1 || res.Results[0].RelPath != "alpha/dup.go" {
+		t.Errorf("file hint should narrow to alpha/dup.go; got %+v", res.Results)
+	}
+
+	// A hint matching no file falls back to the global result set.
+	res, err = flexResolve(dbPath, "nosuch/file.go:Dup")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Results) != 2 {
+		t.Errorf("unmatched hint should fall back to all definitions; got %+v", res.Results)
+	}
+
+	// Pinned: hint matching is HasSuffix/Contains, so a bare basename hint
+	// also matches longer basenames (store.go matches mystore.go). If this
+	// tightens to exact-basename matching, update the show help text too.
+	res, err = flexResolve(dbPath, "store.go:Col")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Results) != 2 {
+		t.Errorf("suffix-collision behaviour changed: want both store.go and mystore.go matches, got %+v", res.Results)
+	}
+
+	// A symbol starting with L resolves through the file hint end to end
+	// (would fail if isFilePath mistook :Load for a line range).
+	if !isFilePath("zeta/loader.go:Load") {
+		res, err = flexResolve(dbPath, "zeta/loader.go:Load")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(res.Results) != 1 || res.Results[0].RelPath != filepath.Join("zeta", "loader.go") {
+			t.Errorf("L-symbol file hint should resolve; got %+v", res.Results)
+		}
+	} else {
+		t.Error("isFilePath must route zeta/loader.go:Load to symbol lookup")
+	}
+
+	// Symbol missing everywhere: the payload error names both the symbol and
+	// the file hint.
+	if _, err := buildShowSymbolPayload(dbPath, "alpha/dup.go:NoSuch", 0, false, nil, nil); err == nil ||
+		!strings.Contains(err.Error(), "NoSuch") || !strings.Contains(err.Error(), "alpha/dup.go") {
+		t.Errorf("scoped not-found error should name symbol and hint; got %v", err)
+	}
+}
+
 func TestRepoBoundFilePathRejectsOutsideRepo(t *testing.T) {
 	defer index.CloseAll()
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -172,18 +172,21 @@ cymbal search parse --kind function --lang go
 Read source code by symbol name or file path.
 
 ```sh
-cymbal show <symbol|file[:L1-L2]> [flags]
+cymbal show <symbol|file[:L1-L2|:Symbol]> [flags]
 ```
 
 | Flag | Description |
 |------|-------------|
 | `-C, --context <n>` | Lines of context around the target |
 
-If the argument contains `/` or ends with a known extension, it's treated as a file path. Otherwise, it's treated as a symbol name.
+`file.go:SymbolName` looks up a symbol with a file hint: results are narrowed to files whose path ends with (or contains) the hint, falling back to global results if nothing matches. Otherwise, an argument containing `/` or ending with a known extension is treated as a file path; anything else is a symbol name.
 
 ```sh
 # Show a symbol's source
 cymbal show handleAuth
+
+# Narrow a common name by file hint
+cymbal show store.go:SearchSymbols
 
 # Show a file
 cymbal show internal/auth/handler.go

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/1broseidon/cymbal
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/coder3101/tree-sitter-proto v0.0.0-20250826173151-a1fbf36c3029


### PR DESCRIPTION
## Summary

The `file:Symbol` syntax (e.g. `cymbal show store.go:SearchSymbols`) already works via `flexResolve`'s `parseSymbolArg`, but was undocumented — and review of this PR surfaced one real routing bug, now fixed here:

- **Fix: symbols starting with `L` were misrouted as line ranges.** `isFilePath` treated any `:L...` suffix as a line range, so `cymbal show index.go:ListRepos` or `store.go:Load` failed with "file not found". Only `:L<digits>` is a line range now.
- Document the file-hint rule in the `Use` line and help text, stated *before* the general contains-`/` file-path rule (hints contain `/` yet are symbol lookups), and worded as *narrowing* rather than strict scoping — matching is `HasSuffix`/`Contains` (so `store.go` also matches `mystore.go`) and falls back to global results when the hint matches nothing.
- Add a `file:Symbol` example and update `docs/reference/commands.md`.
- Improve the not-found error to name both the symbol and the file hint — only when nothing matched before `--path`/`--exclude` filtering, so it never falsely claims "no match globally".
- Table tests pin `isFilePath`/`parseSymbolArg` routing (including `:Load`, `:ListFiles`, bare `:L`); behavioral tests pin hint-wins-on-duplicates, fallback on unmatched hint, the suffix-collision match, L-symbol end-to-end resolution, and the scoped error text.

Includes the go1.26.5 bump from #71 so the `security` job passes; it drops out of this diff once #71 merges.

**Note**: trivial conflict expected with #68 in `cmd/show.go`'s Examples block (both add an example line after `cymbal show ParseFile`) — keep both lines.

## Test plan

- [x] `go test ./cmd/...` green, including the new routing and behavioral tests
- [x] Full suite + CI green
