### PR TITLE
ls: add --names indexed file inventory; fix Glob nudge to use it

### DIFF
--- a/cmd/hook.go
+++ b/cmd/hook.go
@@ -208,6 +208,7 @@ type nudgeInput struct {
 	glob     string // Grep --glob filter
 	fileType string // Grep --type filter
 	filePath string // Read file_path
+	globPath string // Glob path (optional search root)
 }
 
 // detectSearchCommand inspects an already-tokenized argv (first element is
@@ -446,7 +447,7 @@ func detectNudge(in nudgeInput) Suggestion {
 	case "Grep":
 		return detectGrepToolSearch(in.pattern, in.glob, in.fileType)
 	case "Glob":
-		return detectGlobToolSearch(in.pattern)
+		return detectGlobToolSearch(in.pattern, in.globPath)
 	case "Read":
 		return detectReadToolSearch(in.filePath)
 	}
@@ -477,20 +478,34 @@ func detectGrepToolSearch(pattern, glob, fileType string) Suggestion {
 }
 
 // detectGlobToolSearch fires when the Glob tool's pattern targets code files.
-// The natural cymbal equivalent is `cymbal ls --names` (file inventory) or a
-// scoped `cymbal search --path <pattern> <symbol>` once a symbol is in hand —
-// the nudge points at the broader navigation surface rather than a single
-// command, since Glob alone doesn't carry symbol intent.
-func detectGlobToolSearch(pattern string) Suggestion {
-	if pattern == "" {
+// The cymbal equivalent is `cymbal ls --names '<pattern>'` — the indexed file
+// inventory, narrowed by the same pattern. When the Glob call carries an
+// explicit path (search root), the nudge stays silent: the pattern is
+// relative to that root and cannot be rebased reliably to repo-relative form.
+func detectGlobToolSearch(pattern, path string) Suggestion {
+	// "." is Glob's default root, equivalent to no path.
+	if path == "." {
+		path = ""
+	}
+	if pattern == "" || path != "" {
 		return Suggestion{}
 	}
 	if !globTargetsCode(pattern) {
 		return Suggestion{}
 	}
+	// pathmatch has no brace expansion, so a {go,ts}-style pattern would
+	// match nothing — suggest the unfiltered inventory instead.
+	replacement := "cymbal ls --names"
+	if !strings.ContainsAny(pattern, "{}") {
+		quoted := shQuoteIfNeeded(pattern)
+		if strings.HasPrefix(pattern, "-") {
+			quoted = "-- " + quoted
+		}
+		replacement += " " + quoted
+	}
 	return Suggestion{
 		Tool:        "Glob",
-		Replacement: "cymbal ls --names",
+		Replacement: replacement,
 		Why:         "The inventory lists the code files cymbal indexed, with skip rules applied.",
 	}
 }
@@ -717,6 +732,7 @@ func readNudgeInput(args []string) (nudgeInput, error) {
 				Pattern  string `json:"pattern"`
 				Glob     string `json:"glob"`
 				Type     string `json:"type"`
+				Path     string `json:"path"`
 				FilePath string `json:"file_path"`
 			} `json:"tool_input"`
 		}
@@ -730,6 +746,7 @@ func readNudgeInput(args []string) (nudgeInput, error) {
 				return in, nil
 			case "Glob":
 				in.pattern = payload.ToolInput.Pattern
+				in.globPath = payload.ToolInput.Path
 				return in, nil
 			case "Read":
 				in.filePath = payload.ToolInput.FilePath

--- a/cmd/hook_test.go
+++ b/cmd/hook_test.go
@@ -281,6 +281,93 @@ func TestDetectGlobToolCodePattern(t *testing.T) {
 	}
 }
 
+func TestDetectGlobToolPassesPatternThrough(t *testing.T) {
+	s := detectNudge(nudgeInput{toolName: "Glob", pattern: "**/*.go"})
+	if !strings.Contains(s.Replacement, "cymbal ls --names") || !strings.Contains(s.Replacement, "**/*.go") {
+		t.Errorf("Glob nudge should carry the original pattern; got %q", s.Replacement)
+	}
+}
+
+func TestDetectGlobToolWithPathSuppressed(t *testing.T) {
+	// An explicit search root makes the pattern non-repo-relative; the nudge
+	// must stay silent rather than suggest a wrong scope.
+	if s := detectNudge(nudgeInput{toolName: "Glob", pattern: "**/*.go", globPath: "/some/subdir"}); s.Replacement != "" {
+		t.Errorf("Glob with explicit path must not nudge; got %q", s.Replacement)
+	}
+	// "." is Glob's default root — equivalent to no path, so still nudge.
+	if s := detectNudge(nudgeInput{toolName: "Glob", pattern: "**/*.go", globPath: "."}); s.Replacement == "" {
+		t.Error("Glob with path \".\" should still nudge")
+	}
+}
+
+func TestLsNamesRejectsNullWithJSON(t *testing.T) {
+	if err := lsNamesCheckFlags(true, true); err == nil || !strings.Contains(err.Error(), "--null") {
+		t.Errorf("expected --null/--json rejection, got %v", err)
+	}
+	if err := lsNamesCheckFlags(true, false); err != nil {
+		t.Errorf("--null alone must be accepted, got %v", err)
+	}
+}
+
+func TestDetectGlobToolBracePatternUnfiltered(t *testing.T) {
+	// pathmatch has no brace expansion; the nudge must not pass a pattern
+	// that would match nothing.
+	s := detectNudge(nudgeInput{toolName: "Glob", pattern: "**/*.{go,ts}"})
+	if s.Replacement != "cymbal ls --names" {
+		t.Errorf("brace pattern should suggest unfiltered inventory; got %q", s.Replacement)
+	}
+}
+
+func TestDetectGlobToolHyphenPatternTerminated(t *testing.T) {
+	s := detectNudge(nudgeInput{toolName: "Glob", pattern: "-weird*.go"})
+	if s.Replacement == "" {
+		t.Fatal("leading-hyphen code pattern should still nudge")
+	}
+	if !strings.Contains(s.Replacement, "-- ") {
+		t.Errorf("leading-hyphen pattern needs a -- terminator; got %q", s.Replacement)
+	}
+}
+
+// TestNudgeReplacementsParse pins that every suggested command actually
+// exists: the subcommand resolves and each --flag is defined on it. This
+// catches nudges that advertise commands or flags that were never shipped.
+func TestNudgeReplacementsParse(t *testing.T) {
+	suggestions := []Suggestion{
+		detectNudge(nudgeInput{toolName: "Glob", pattern: "**/*.go"}),
+		detectNudge(nudgeInput{toolName: "Read", filePath: "/repo/src/handler.go"}),
+		detectNudge(nudgeInput{toolName: "Grep", pattern: "HandleAuth"}),
+	}
+	for _, s := range suggestions {
+		if s.Replacement == "" {
+			t.Fatalf("expected a suggestion for every fixture; got %+v", s)
+		}
+		// Tokenize the way a shell would (handles quoted patterns with
+		// spaces); "--" terminates flag parsing.
+		fields := splitShellish(s.Replacement)
+		if len(fields) < 2 || fields[0] != "cymbal" {
+			t.Errorf("suggestion %q should start with a cymbal subcommand", s.Replacement)
+			continue
+		}
+		cmd, rest, err := rootCmd.Find(fields[1:])
+		if err != nil || cmd == rootCmd {
+			t.Errorf("suggestion %q does not resolve to a subcommand: %v", s.Replacement, err)
+			continue
+		}
+		for _, tok := range rest {
+			if tok == "--" {
+				break
+			}
+			if !strings.HasPrefix(tok, "--") {
+				continue
+			}
+			name := strings.TrimPrefix(tok, "--")
+			if cmd.Flags().Lookup(name) == nil && cmd.InheritedFlags().Lookup(name) == nil {
+				t.Errorf("suggestion %q uses flag --%s not defined on %q", s.Replacement, name, cmd.Name())
+			}
+		}
+	}
+}
+
 func TestDetectGlobToolNonCodePatternSkipped(t *testing.T) {
 	for _, pat := range []string{"*.json", "**/*.md", "logs/*.log", "*.yaml"} {
 		if s := detectNudge(nudgeInput{toolName: "Glob", pattern: pat}); s.Replacement != "" {

--- a/cmd/ls.go
+++ b/cmd/ls.go
@@ -12,14 +12,21 @@ import (
 )
 
 var lsCmd = &cobra.Command{
-	Use:   "ls [path]",
-	Short: "Show file tree, repo list, or repo stats",
-	Long: `Show the file tree of a directory (default), list all indexed repos (--repos),
-or show repo statistics (--stats).`,
+	Use:   "ls [path|pattern]",
+	Short: "Show file tree, indexed file names, repo list, or repo stats",
+	Long: `Show the file tree of a directory (default), the flat list of indexed files
+(--names), all indexed repos (--repos), or repo statistics (--stats).
+
+--names lists repo-relative paths of the files cymbal indexed, one per line,
+sorted — the code inventory after skip rules (generated/vendored/large files
+excluded under default index options). The optional argument narrows it with the same semantics as the
+--path/--exclude filters: substring for plain strings, glob with ** otherwise.
+Filter by language with --lang (names as shown by 'cymbal ls --stats').`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		repos, _ := cmd.Flags().GetBool("repos")
 		stats, _ := cmd.Flags().GetBool("stats")
+		names, _ := cmd.Flags().GetBool("names")
 		jsonOut := getJSONFlag(cmd)
 
 		if repos {
@@ -28,6 +35,9 @@ or show repo statistics (--stats).`,
 		if stats {
 			return lsStats(cmd, jsonOut)
 		}
+		if names {
+			return lsNames(cmd, args, jsonOut)
+		}
 		return lsTree(cmd, args, jsonOut)
 	},
 }
@@ -35,8 +45,56 @@ or show repo statistics (--stats).`,
 func init() {
 	lsCmd.Flags().Bool("repos", false, "list all indexed repositories")
 	lsCmd.Flags().Bool("stats", false, "show repo overview (languages, file/symbol counts)")
+	lsCmd.Flags().Bool("names", false, "flat list of indexed file paths (optionally narrowed by pattern)")
+	lsCmd.Flags().String("lang", "", "with --names: only files of this language")
+	lsCmd.Flags().Bool("null", false, "with --names: NUL-terminate entries (for xargs -0)")
 	lsCmd.Flags().IntP("depth", "D", 0, "max tree depth (0 = unlimited)")
 	rootCmd.AddCommand(lsCmd)
+}
+
+// lsNamesCheckFlags rejects contradictory output modes.
+func lsNamesCheckFlags(nulSep, jsonOut bool) error {
+	if nulSep && jsonOut {
+		return fmt.Errorf("--null cannot be combined with --json")
+	}
+	return nil
+}
+
+// lsNames prints the sorted repo-relative paths of indexed files. Empty
+// result is success (empty output; --json emits [], never null).
+func lsNames(cmd *cobra.Command, args []string, jsonOut bool) error {
+	dbPath := getDBPath(cmd)
+	ensureFresh(dbPath)
+
+	language, _ := cmd.Flags().GetString("lang")
+	nulSep, _ := cmd.Flags().GetBool("null")
+	pattern := ""
+	if len(args) > 0 {
+		pattern = args[0]
+	}
+
+	if err := lsNamesCheckFlags(nulSep, jsonOut); err != nil {
+		return err
+	}
+
+	names, err := index.ListFileNames(dbPath, language, pattern)
+	if err != nil {
+		return err
+	}
+	if jsonOut {
+		if names == nil {
+			names = []string{}
+		}
+		return writeJSON(names)
+	}
+	sep := "\n"
+	if nulSep {
+		sep = "\x00"
+	}
+	for _, n := range names {
+		fmt.Printf("%s%s", n, sep)
+	}
+	return nil
 }
 
 func lsRepos(jsonOut bool) error {

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -79,7 +79,7 @@ cymbal version [--json]
 Show file tree, repo list, or repo statistics.
 
 ```sh
-cymbal ls [path] [flags]
+cymbal ls [path|pattern] [flags]
 ```
 
 | Flag | Description |
@@ -87,6 +87,9 @@ cymbal ls [path] [flags]
 | `-D, --depth <n>` | Max tree depth (0 = unlimited) |
 | `--repos` | List all indexed repositories |
 | `--stats` | Show repo overview (languages, file/symbol counts) |
+| `--names` | Flat sorted list of indexed file paths (one per line) |
+| `--lang <language>` | With `--names`: only files of this language |
+| `--null` | With `--names`: NUL-terminate entries (for `xargs -0`) |
 
 ```sh
 # File tree
@@ -100,6 +103,16 @@ cymbal ls --stats
 
 # All indexed repos
 cymbal ls --repos
+
+# Indexed file inventory (skip rules applied under default index options)
+cymbal ls --names
+
+# Narrow by pattern (same semantics as --path/--exclude) or language
+cymbal ls --names 'parser/**'
+cymbal ls --names --lang typescript
+
+# Feed batch commands (NUL-safe)
+cymbal ls --names --null 'cmd/**' | xargs -0 -n1 cymbal outline
 ```
 
 ---

--- a/index/index.go
+++ b/index/index.go
@@ -19,6 +19,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/1broseidon/cymbal/internal/pathmatch"
 	"github.com/1broseidon/cymbal/lang"
 	"github.com/1broseidon/cymbal/parser"
 	"github.com/1broseidon/cymbal/symbols"
@@ -740,6 +741,30 @@ func SearchSymbols(dbPath string, q SearchQuery) ([]SymbolResult, error) {
 		return nil, err
 	}
 	return store.SearchSymbols(q.Text, q.Kind, q.Language, q.Exact, q.IgnoreCase, q.Limit)
+}
+
+// ListFileNames returns the repo-relative paths of indexed files, sorted,
+// optionally filtered by exact language name and by a pathmatch pattern
+// (same semantics as the CLI --path/--exclude filters: substring for plain
+// strings, glob with ** support otherwise). The result reflects the current
+// index contents: files skipped by walk rules or exclusions are absent.
+func ListFileNames(dbPath, language, pattern string) ([]string, error) {
+	store, err := openCached(dbPath)
+	if err != nil {
+		return nil, err
+	}
+	files, err := store.AllFiles(language)
+	if err != nil {
+		return nil, err
+	}
+	names := make([]string, 0, len(files))
+	for _, f := range files {
+		if pattern != "" && !pathmatch.MatchAny(f.RelPath, []string{pattern}) {
+			continue
+		}
+		names = append(names, f.RelPath)
+	}
+	return names, nil
 }
 
 // RepoStats returns overview statistics for the repo in the given database.

--- a/index/index_feature_test.go
+++ b/index/index_feature_test.go
@@ -3,6 +3,7 @@ package index
 import (
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -769,5 +770,74 @@ func TestFeatureScopedExcludeIsRepoRelative(t *testing.T) {
 	}
 	if stats.StaleRemoved != 1 {
 		t.Errorf("StaleRemoved = %d, want 1 (excluded file pruned from DB)", stats.StaleRemoved)
+	}
+}
+func TestFeatureListFileNames(t *testing.T) {
+	dir := createTestRepo(t)
+	for rel, content := range map[string]string{
+		"sub/helper.go":        "package sub\nfunc SubHelper() {}\n",
+		"web/app.ts":           "export const app = 1\n",
+		"node_modules/skip.js": "var x = 1\n",
+	} {
+		path := filepath.Join(dir, rel)
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	dbPath := filepath.Join(t.TempDir(), "test.db")
+	if _, err := Index(dir, dbPath, Options{Workers: 2}); err != nil {
+		t.Fatal(err)
+	}
+
+	names, err := ListFileNames(dbPath, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	has := func(want string) bool {
+		for _, n := range names {
+			if n == want {
+				return true
+			}
+		}
+		return false
+	}
+	if !has(filepath.Join("sub", "helper.go")) || !has(filepath.Join("web", "app.ts")) {
+		t.Errorf("expected indexed files in listing; got %v", names)
+	}
+	for _, n := range names {
+		if strings.Contains(n, "node_modules") {
+			t.Errorf("skip rules must apply: %v", names)
+		}
+	}
+	if !sort.StringsAreSorted(names) {
+		t.Errorf("names must be sorted; got %v", names)
+	}
+
+	tsOnly, err := ListFileNames(dbPath, "typescript", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(tsOnly) != 1 || tsOnly[0] != filepath.Join("web", "app.ts") {
+		t.Errorf("lang filter: want only web/app.ts, got %v", tsOnly)
+	}
+
+	subOnly, err := ListFileNames(dbPath, "", "sub/**")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(subOnly) != 1 || subOnly[0] != filepath.Join("sub", "helper.go") {
+		t.Errorf("glob pattern: want only sub/helper.go, got %v", subOnly)
+	}
+
+	none, err := ListFileNames(dbPath, "", "zz-no-such-path")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(none) != 0 {
+		t.Errorf("no-match pattern: want empty, got %v", none)
 	}
 }


### PR DESCRIPTION
## Summary

The Glob nudge has recommended `cymbal ls --names` since it shipped in PR #47 — but the flag never existed, so every nudged agent got `unknown flag: --names`. This implements the inventory that nudge always promised, rather than papering over the reference:

- **`cymbal ls --names [pattern]`** — flat, sorted, repo-relative list of indexed files straight from the `files` table: the code inventory after skip rules (generated/vendored/large files absent). The optional pattern uses the same `pathmatch` semantics as `--path`/`--exclude` (substring for plain strings, glob with `**` otherwise), so it doubles as a dry-run preview of those filters.
- **`--lang <language>`** filters by indexed language (names as shown by `ls --stats`); **`--null`** NUL-terminates entries for `xargs -0`; **`--json`** emits `results: []`, never null. Empty result is success.
- **Glob nudge fixes**: the suggestion carries the original pattern through (`cymbal ls --names '<pattern>'`), with edge cases handled: brace patterns (`**/*.{go,ts}`) suggest the unfiltered inventory since `pathmatch` has no brace expansion; leading-hyphen patterns get a `--` terminator; the nudge stays silent when the Glob call has an explicit `path` root (previously silently discarded — a root-relative pattern can't be reliably rebased), except `"."` which is Glob's default and equivalent to no path.
- `--null` with `--json` is rejected rather than silently ignored.
- **`TestNudgeReplacementsParse`** pins that every nudge suggestion resolves to a real subcommand with real flags, so a nudge can never again advertise a command that doesn't exist.

Library addition: `index.ListFileNames(dbPath, language, pattern)` (thin wrapper over the existing `Store.AllFiles`).

Includes the go1.26.5 bump from #71 so the `security` job passes; it drops out of this diff once #71 merges.

**Note**: expect a trivial conflict with #70 in `detectGlobToolSearch` (both touch the Suggestion literal — #70 rewords `Why`, this PR rewrites `Replacement`). Resolution: keep both changes.

## Test plan

- [x] `TestFeatureListFileNames`: skip rules applied, language filter, glob pattern, sorted order, empty-match success
- [x] Hook tests: pattern pass-through, explicit-path suppression, replacement parse validation
- [x] Full suite + `go vet` green; smoke-tested `ls --names` with pattern/lang/json on a live repo
