### PR TITLE
build: bump go directive to 1.26.7 for stdlib vuln fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/1broseidon/cymbal
 
-go 1.26.5
+go 1.26.7
 
 require (
 	github.com/coder3101/tree-sitter-proto v0.0.0-20250826173151-a1fbf36c3029


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Pin `go.mod` from 1.26.5 to 1.26.7 so CI installs a toolchain that covers the four stdlib findings now failing `govulncheck` on main (`GO-2026-6218`, `GO-2026-6090`, `GO-2026-5972`, `GO-2026-5026`). All four report "Fixed in: go1.26.6"; 1.26.7 is the current 1.26 patch (released 2026-08-19).
- Same one-line change as #71. `setup-go` uses `go-version-file: go.mod`.

## Testing

- Commands run:
  - `GOTOOLCHAIN=go1.26.7 go run golang.org/x/vuln/cmd/govulncheck@latest ./...` → No vulnerabilities found
- Extra validation:
  - Reproduces https://github.com/1broseidon/cymbal/actions/runs/32384316534 (security job only; build/lint/test were green)
  - This PR's CI is green, including the security job

This is a 1-line `go.mod` pin; no code or docs change.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-94ed3d75-ed74-41be-bdb3-a7b8ea3e8bcc?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-94ed3d75-ed74-41be-bdb3-a7b8ea3e8bcc&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

